### PR TITLE
fix(ModelBreakdown): lighten tooltip text color

### DIFF
--- a/src/components/ModelBreakdown.tsx
+++ b/src/components/ModelBreakdown.tsx
@@ -30,6 +30,8 @@ export function ModelBreakdown({ models }: { models: ModelShare[] }) {
                 borderRadius: 12,
                 fontSize: 12,
               }}
+              itemStyle={{ color: '#e4e4e7' }}
+              labelStyle={{ color: '#e4e4e7' }}
               formatter={(value: number, name: string) => [compact(value), shortModel(name)]}
             />
           </PieChart>


### PR DESCRIPTION
## Summary
- Set `itemStyle` and `labelStyle` color to `#e4e4e7` (zinc-200) on the model breakdown donut chart tooltip
- Fixes tooltip text being too dark to read against the dark background

## Test plan
- [ ] `npm run dev`
- [ ] Hover over model breakdown chart - tooltip text should be light/readable