### PR TITLE
feat: add skeleton loading states to dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "claude-dashboard",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
         "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,15 @@ import { ActivityHeatmap } from './components/ActivityHeatmap';
 import { ToolUsage } from './components/ToolUsage';
 import { LiveBadge } from './components/LiveBadge';
 import { LimitsPanel } from './components/LimitsPanel';
+import {
+  StatCardSkeleton,
+  ChartSkeleton,
+  GaugeSkeleton,
+  DonutSkeleton,
+  BarsSkeleton,
+  HeatmapSkeleton,
+  Skeleton,
+} from './components/Skeleton';
 import { compact, usd, hourLabel, dayLabel, shortModel } from './lib/format';
 
 const POLL = 5000;
@@ -119,6 +128,14 @@ export default function App() {
         <div className="mt-6 space-y-6">
           {/* Stat cards */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {recent.loading || weekly.loading ? (
+              <>
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+              </>
+            ) : (
+              <>
             <StatCard
               label="Effective tokens · current block"
               value={compact(block?.totals.effectiveTokens ?? 0)}
@@ -157,16 +174,20 @@ export default function App() {
               value={usd(weekly.data?.totals.cost ?? 0)}
               sub={topModel ? `top: ${shortModel(topModel.model)}` : undefined}
             />
+              </>
+            )}
           </div>
 
           {/* 5-hour panel */}
           <div className="grid grid-cols-1 items-stretch gap-6 lg:grid-cols-3">
-            <BlockGauge block={block} limits={limits} />
+            {recent.loading ? <GaugeSkeleton /> : <BlockGauge block={block} limits={limits} />}
             <div className="flex flex-col lg:col-span-2">
               <Section title="Last 5 hours · hourly tokens by model" grow>
-                {recent.data && (
+                {recent.data ? (
                   <UsageBarChart buckets={recent.data.buckets} labelFor={hourLabel} />
-                )}
+                ) : recent.loading ? (
+                  <ChartSkeleton />
+                ) : null}
               </Section>
             </div>
           </div>
@@ -205,9 +226,15 @@ export default function App() {
                   </div>
                 }
               >
-                {weekly.data && <UsageBarChart buckets={weekly.data.buckets} labelFor={dayLabel} />}
+                {weekly.data ? (
+                  <UsageBarChart buckets={weekly.data.buckets} labelFor={dayLabel} />
+                ) : weekly.loading ? (
+                  <ChartSkeleton />
+                ) : null}
                 <div className="mt-4 rounded-xl bg-ink-700/50 px-4 py-3">
-                  {limits.weeklyLimit ? (
+                  {weekly.loading ? (
+                    <Skeleton className="h-4 w-full rounded" />
+                  ) : limits.weeklyLimit ? (
                     <div className="flex-1">
                       <div className="flex justify-between text-xs text-zinc-400">
                         <span>
@@ -253,18 +280,28 @@ export default function App() {
           {/* Model + tool usage */}
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             <Section title="Model breakdown · 7d">
-              {models.data && <ModelBreakdown models={models.data.models} />}
+              {models.data ? (
+                <ModelBreakdown models={models.data.models} />
+              ) : models.loading ? (
+                <DonutSkeleton />
+              ) : null}
             </Section>
             <Section title="Tool usage · 7d">
-              {tools.data && (
+              {tools.data ? (
                 <ToolUsage tools={tools.data.tools} totalCalls={tools.data.totalCalls} />
-              )}
+              ) : tools.loading ? (
+                <BarsSkeleton />
+              ) : null}
             </Section>
           </div>
 
           {/* Activity */}
           <Section title="Daily activity · last 18 weeks">
-            {activity.data && <ActivityHeatmap days={activity.data.dailyActivity} />}
+            {activity.data ? (
+              <ActivityHeatmap days={activity.data.dailyActivity} />
+            ) : activity.loading ? (
+              <HeatmapSkeleton />
+            ) : null}
           </Section>
         </div>
       )}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,90 @@
+import type { CSSProperties } from 'react';
+
+/** Base shimmering placeholder. Sizing/rounding come from className. */
+export function Skeleton({ className = '', style }: { className?: string; style?: CSSProperties }) {
+  return <div className={`skeleton ${className}`} style={style} />;
+}
+
+/** Matches StatCard: label, big value, sub line. */
+export function StatCardSkeleton() {
+  return (
+    <div className="card p-5">
+      <Skeleton className="h-3 w-32 rounded" />
+      <Skeleton className="mt-3 h-8 w-24 rounded" />
+      <Skeleton className="mt-3 h-3 w-full rounded-full" />
+    </div>
+  );
+}
+
+/** Matches UsageBarChart's h-[260px] bar chart. */
+export function ChartSkeleton({ heightClass = 'h-[260px]' }: { heightClass?: string }) {
+  const bars = [55, 80, 40, 95, 65, 50, 85, 60, 90, 45, 70, 35];
+  return (
+    <div className={`flex w-full items-end gap-2 ${heightClass}`}>
+      {bars.map((h, i) => (
+        <Skeleton key={i} className="flex-1 rounded-t" style={{ height: `${h}%` }} />
+      ))}
+    </div>
+  );
+}
+
+/** Matches BlockGauge card: title, ring, detail rows. */
+export function GaugeSkeleton() {
+  return (
+    <div className="card flex flex-col items-center justify-center p-6">
+      <Skeleton className="h-3 w-40 rounded" />
+      <Skeleton className="mt-4 h-[200px] w-[200px] rounded-full" />
+      <div className="mt-5 w-full space-y-2">
+        <Skeleton className="h-3 w-full rounded" />
+        <Skeleton className="h-3 w-2/3 rounded" />
+      </div>
+    </div>
+  );
+}
+
+/** Matches ModelBreakdown: donut + legend list. */
+export function DonutSkeleton() {
+  return (
+    <div className="flex items-center gap-4">
+      <Skeleton className="h-[200px] w-[200px] shrink-0 rounded-full" />
+      <div className="flex-1 space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full rounded" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Matches ToolUsage: rows of label + bar + count. */
+export function BarsSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-3 w-24 shrink-0 rounded" />
+          <Skeleton className="h-2 flex-1 rounded-full" />
+          <Skeleton className="h-3 w-8 shrink-0 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Matches ActivityHeatmap: grid of small day squares. */
+export function HeatmapSkeleton({ weeks = 18 }: { weeks?: number }) {
+  return (
+    <div>
+      <Skeleton className="mb-3 h-3 w-48 rounded" />
+      <div className="flex gap-1">
+        {Array.from({ length: weeks }).map((_, c) => (
+          <div key={c} className="flex flex-col gap-1">
+            {Array.from({ length: 7 }).map((_, r) => (
+              <Skeleton key={r} className="h-3 w-3 rounded-sm" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,22 @@ body {
     box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.6);
     animation: pulse 2s infinite;
   }
+  .skeleton {
+    @apply relative overflow-hidden bg-white/5;
+  }
+  .skeleton::after {
+    content: '';
+    @apply absolute inset-0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+    transform: translateX(-100%);
+    animation: shimmer 1.5s infinite;
+  }
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
Adds shimmering **skeleton loaders** so the dashboard shows placeholder UI during the brief window before the first data poll returns, instead of empty sections / zeroed-out cards.

## Changes
- **`src/index.css`** — new `.skeleton` shimmer utility (animated gradient sweep) in the existing `@layer components`, plus a `shimmer` keyframe.
- **`src/components/Skeleton.tsx`** (new) — a base `Skeleton` plus section-matched placeholders sized to the real components: `StatCardSkeleton`, `ChartSkeleton` (260px), `GaugeSkeleton` (200px ring), `DonutSkeleton`, `BarsSkeleton`, `HeatmapSkeleton`.
- **`src/App.tsx`** — each section renders its skeleton while its `usePolling` hook is in the initial `loading` state, then swaps to real data: stat cards, 5-hour gauge + hourly chart, weekly chart + summary bar, model breakdown, tool usage, and the activity heatmap.

## Behavior notes
- Skeletons key off `loading`, so they appear only on first load — not on the 5s background re-polls.
- A hard fetch error won't leave skeletons shimmering forever (gated on `loading`, not just missing data).
- The empty-state message ("No usage logs found") still only shows after loading completes with zero data, so it won't flash during startup.

## Testing
- `tsc -b` passes (typecheck clean).
- Built and ran via Docker (`npm run docker:up`); verified http://localhost:8787 returns 200 and the served CSS/JS bundles include the skeleton styles and components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)