### PR TITLE
feat: track Claude Cowork usage with source filter + card help tooltips

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,18 @@
 # Windows (Docker Desktop) — use forward slashes:
 #   CLAUDE_DIR_HOST=C:/Users/you/.claude
 CLAUDE_DIR_HOST=C:/Users/you/.claude
+
+# OPTIONAL — Claude Cowork ("local agent mode" in the desktop app). Point this at
+# the desktop app's local-agent-mode-sessions folder to also track Cowork usage.
+# Leave it unset if you don't use Cowork; the dashboard simply won't show it.
+#
+# macOS:
+#   COWORK_DIR_HOST=/Users/you/Library/Application Support/Claude/local-agent-mode-sessions
+# Windows (Docker Desktop) — use forward slashes:
+#   COWORK_DIR_HOST=C:/Users/you/AppData/Roaming/Claude/local-agent-mode-sessions
+# Linux:
+#   COWORK_DIR_HOST=/home/you/.config/Claude/local-agent-mode-sessions
+#
+# Note: Cowork runs in *full-VM sandbox* mode keep their transcripts inside the VM,
+# so only host-side local-agent sessions are captured.
+#COWORK_DIR_HOST=C:/Users/you/AppData/Roaming/Claude/local-agent-mode-sessions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,13 @@ There is **no test suite and no linter** configured. Correctness is enforced by 
 
 ### Pointing at a different data folder
 
-`CLAUDE_DIR` overrides the scanned folder (default `~/.claude`). `SERVER_PORT` overrides `8787` — **if you change it, also update the proxy target in `vite.config.ts`** or the UI's `/api` calls break in dev.
+`CLAUDE_DIR` overrides the scanned folder (default `~/.claude`). `COWORK_DIR` overrides the Cowork desktop root (default is OS-specific — see `coworkDir()` in `scan.ts`); the dashboard auto-detects it when present, so most users never set it. `SERVER_PORT` overrides `8787` — **if you change it, also update the proxy target in `vite.config.ts`** or the UI's `/api` calls break in dev.
 
 ```powershell
 $env:CLAUDE_DIR = "D:\backups\.claude"; npm run dev
 ```
+
+In Docker, `~/.claude` and the Cowork root are mounted read-only at `/data/.claude` and `/data/cowork` (`CLAUDE_DIR_HOST` / `COWORK_DIR_HOST` in `.env`). `COWORK_DIR_HOST` is optional; unset, it falls back to the `.claude` mount and yields zero cowork events.
 
 ## Architecture
 
@@ -41,11 +43,12 @@ Two processes in dev; one in Docker. The data flow on the backend is always **sc
 
 ### Backend (`server/`, plain TypeScript run directly by `tsx` — never compiled, even in Docker)
 
-- **`scan.ts`** — the only code that touches disk. Recursively reads every `*.jsonl` under `<claudeDir>/projects`, keeps lines where `type === 'assistant'` with a `message.usage`, and emits a flat `UsageEvent[]` (timestamp, sessionId, model, token counts, tool names). **Dedup is by `requestId:message.id`** because streaming/retries write the same logical response multiple times. Also reads the sidecar files: `settings.json`, `.credentials.json`, `stats-cache.json`, and `usage-data/session-meta/*.json`. `fetchLiveUsage()` calls Anthropic's OAuth usage API with the stored access token (30s in-memory cache).
+- **`scan.ts`** — the only code that touches disk. Recursively reads every `*.jsonl` under each of `scanRoots()`, keeps lines where `type === 'assistant'` with a `message.usage`, and emits a flat `UsageEvent[]` (timestamp, sessionId, model, token counts, tool names, **`source`**). **Dedup is by `requestId:message.id`** (shared across all roots) because streaming/retries — and the same `cliSessionId` writing to two roots — produce the same logical response multiple times. Also reads the sidecar files: `settings.json`, `.credentials.json`, `stats-cache.json`, and `usage-data/session-meta/*.json`. `fetchLiveUsage()` calls Anthropic's OAuth usage API with the stored access token (30s in-memory cache).
+- **Scan roots / `source`** — `scanRoots()` returns `<claudeDir>/projects` (`source: 'code'`) plus, when present, the **Cowork** desktop root (`source: 'cowork'`). Cowork = the desktop app's "local agent mode": it writes standard Claude Code JSONL under `<coworkDir>/<acct>/<profile>/<sessionId>/.claude/projects/**/*.jsonl`, so the existing parser ingests it unchanged. `keepScanFile()` keeps only cowork files under a `.claude/projects/` segment (skips `audit.jsonl`/metadata). `coworkDir()` defaults per-OS (win32 `%APPDATA%/Claude/...`, darwin `~/Library/Application Support/Claude/...`, linux `~/.config/Claude/...`) and is overridable via `COWORK_DIR`. **`insights-scan.ts` walks the same `scanRoots()`** so the Sessions/Insights tabs stay in sync. Cowork `projectPath` is left blank (sandbox-internal paths are meaningless on the host) → excluded from the Projects tab. **Caveats:** Cowork runs in *full-VM sandbox* mode keep transcripts inside the VM → not captured; **Claude Chat has no usable local token data** (server-side only) and is out of scope beyond `/api/usage/live`.
 - **`cache.ts`** — wraps `scanEvents()` in a 5s TTL cache keyed off a cheap fingerprint (newest `mtime` across all jsonl files). All `/api/usage/*` endpoints go through `getEvents()`; a full re-scan only happens when files actually changed.
 - **`aggregate.ts`** — pure functions (`buildRecent`, `buildWeekly`, `buildModels`, `buildActivity`, `buildTools`) that bucket the event array by time. No I/O. This is where the domain rules live (see below).
 - **`pricing.ts`** — regex→price table for the *estimated equivalent API cost* only (subscription usage has no real per-token bill). **Order in `TABLE` matters**: specific patterns (e.g. `opus-4-[5-8]`) must precede generic fallbacks (`opus`), first match wins.
-- **`index.ts`** — Express routes. Every response is wrapped as `{ data, computedAt, claudeDir }` (the `Envelope`). Query params are clamped server-side (e.g. `hours` 1–72, `days` 7–28). When `dist/` exists it also serves the static UI with an SPA fallback for non-`/api` routes.
+- **`index.ts`** — Express routes. Every response is wrapped as `{ data, computedAt, claudeDir }` (the `Envelope`). Query params are clamped server-side (e.g. `hours` 1–72, `days` 7–28). Usage/sessions routes accept `?source=all|code|cowork` (`filterSource()` narrows events before the builder runs). **`GET /api/sources`** reports per-surface event counts and `cowork.available` — the frontend gates **all** Cowork UI on it so Code-only users see the original dashboard unchanged. When `dist/` exists it also serves the static UI with an SPA fallback for non-`/api` routes.
 
 ### Domain rules to preserve
 
@@ -59,7 +62,7 @@ These are deliberate and easy to break:
 
 ### Frontend (`src/`)
 
-- **`App.tsx`** is the whole layout: a 4-tab dashboard (Live / Trends / Models / Sessions). Each data source is an independent `usePolling(url, intervalMs)` call — there is no global store. Polling intervals differ per endpoint (5s for live usage charts, 15s for the live API, 30–60s for slow-moving data).
+- **`App.tsx`** is the whole layout: a tabbed dashboard (Live / Agents / Trends / Models / Insights / Sessions). Each data source is an independent `usePolling(url, intervalMs)` call — there is no global store. Polling intervals differ per endpoint (5s for live usage charts, 15s for the live API, 30–60s for slow-moving data). A header **source** toggle (Code / Cowork / All) is rendered **only when `/api/sources` reports `cowork.available`**; it appends `&source=` to the data URLs via `withSrc()` — when Cowork is absent the URLs (and the whole UI) are unchanged.
 - **`hooks/usePolling.ts`** — generic fetch-on-interval hook returning `{ data, computedAt, claudeDir, error, loading }` unwrapped from the `Envelope`.
 - **`hooks/useLimits.ts`** — user-set USD spend caps persisted in `localStorage` (key `claude-dashboard-limits-v2`); purely client-side, never sent to the backend.
 - Components live in `components/design-system/{atoms,molecules,organisms}/` (atomic design). One folder per component: `Name.tsx` (component only), `types.ts` (all prop interfaces), `utils.ts` (module-level helpers), and — atoms only — `Name.variants.ts` with `class-variance-authority` variants. Shared primitives: `ProgressBar`, `ToggleGroup`, `Badge`, `LegendDot` (atoms); `Section`, `ChartTooltip`, `HoverTooltip`, `ExportButton` (molecules) — reuse these instead of re-inlining track/fill divs, button groups, pills, or tooltip cards. Imports across folders use the `@/` alias (→ `src/`); same-folder imports stay relative.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       # Mount your real ~/.claude into the container, read-only.
       # Set CLAUDE_DIR_HOST in a .env file (see .env.example).
       - "${CLAUDE_DIR_HOST}:/data/.claude:ro"
+      # Claude Cowork (desktop "local agent mode") data, read-only. Optional:
+      # if COWORK_DIR_HOST is unset it falls back to .claude, which contains no
+      # nested .claude/projects transcripts at the scanned depth → zero cowork
+      # events (harmless) and the container still boots. See .env.example.
+      - "${COWORK_DIR_HOST:-${CLAUDE_DIR_HOST}}:/data/cowork:ro"
     environment:
       - CLAUDE_DIR=/data/.claude
+      - COWORK_DIR=/data/cowork
       - SERVER_PORT=8787
       - APP_RUNTIME=docker
       # Day buckets follow the container clock — pin it to your local timezone

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/aggregate.ts
+++ b/server/aggregate.ts
@@ -1,4 +1,4 @@
-import type { UsageEvent } from './scan.ts';
+import type { UsageEvent, UsageSource } from './scan.ts';
 import { estimateCost } from './pricing.ts';
 
 const HOUR = 3600_000;
@@ -98,6 +98,27 @@ function sumTotals(events: UsageEvent[]): TokenTotals {
   return t;
 }
 
+export interface SourceSplit {
+  code: TokenTotals;
+  cowork: TokenTotals;
+}
+
+/** Effective-token totals split by surface (Code vs Cowork) for the Sources card. */
+function sourceSplit(events: UsageEvent[]): SourceSplit {
+  const code = emptyTotals();
+  const cowork = emptyTotals();
+  for (const e of events) add(e.source === 'cowork' ? cowork : code, e);
+  return { code, cowork };
+}
+
+export type SourceFilter = 'all' | UsageSource;
+
+/** Narrow an event list to one surface; 'all' passes everything through. */
+export function filterSource(events: UsageEvent[], source: SourceFilter): UsageEvent[] {
+  if (source === 'all') return events;
+  return events.filter((e) => e.source === source);
+}
+
 export interface ActiveBlock {
   start: number;
   resetsAt: number;
@@ -183,6 +204,7 @@ export function buildRecent(events: UsageEvent[], now: number, hours = 5) {
     buckets: bucketize(events, from, now, HOUR),
     totals: sumTotals(windowEvents),
     byModel: modelShares(windowEvents),
+    bySource: sourceSplit(windowEvents),
     activeBlock: computeActiveBlock(events, now),
   };
 }
@@ -213,6 +235,7 @@ export function buildWeekly(events: UsageEvent[], now: number, days = 7) {
     totals: sumTotals(windowEvents),
     prevTotals: sumTotals(prevEvents),
     byModel: modelShares(windowEvents),
+    bySource: sourceSplit(windowEvents),
     cacheEfficiency,
   };
 }
@@ -349,7 +372,9 @@ export function buildProjectStats(events: UsageEvent[], now: number, days: numbe
   }>();
 
   for (const e of events) {
-    if (e.ts < from || !e.projectPath) continue;
+    // Cowork sessions carry sandbox-internal paths, so they're excluded here
+    // (projectPath is blank for them anyway — this is belt-and-suspenders).
+    if (e.ts < from || !e.projectPath || e.source === 'cowork') continue;
     let p = map.get(e.projectPath);
     if (!p) {
       p = { path: e.projectPath, effectiveTokens: 0, cost: 0, sessionIds: new Set() };

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,12 +6,12 @@ import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import express from 'express';
 import { getEvents } from './cache.ts';
-import { buildRecent, buildWeekly, buildModels, buildActivity, buildTools, buildHourlyHeatmap, buildProjectStats } from './aggregate.ts';
+import { buildRecent, buildWeekly, buildModels, buildActivity, buildTools, buildHourlyHeatmap, buildProjectStats, filterSource, type SourceFilter } from './aggregate.ts';
 import { claudeDir, readConfig, readCredentials, readStatsSummary, readSessionMetas, fetchLiveUsage } from './scan.ts';
 import { getInsights } from './insights-scan.ts';
 import {
   buildErrors, buildRetries, buildLanguages, buildBranches, buildMcp,
-  buildComplexity, buildYield, buildRejections, buildSubagentStats,
+  buildComplexity, buildYield, buildRejections, buildSubagentStats, scopeInsights,
 } from './insights.ts';
 import { getLiveSubagents } from './subagents-live.ts';
 import { getVersionInfo, isDocker } from './version.ts';
@@ -23,6 +23,11 @@ const PORT = Number(process.env.SERVER_PORT ?? 8787);
 
 function wrap(data: unknown, computedAt: number) {
   return { data, computedAt, claudeDir: claudeDir() };
+}
+
+/** Parse the optional ?source=all|code|cowork filter (default 'all'). */
+function parseSource(raw: unknown): SourceFilter {
+  return raw === 'code' || raw === 'cowork' ? raw : 'all';
 }
 
 app.get('/api/health', (_req, res) => {
@@ -87,8 +92,9 @@ app.get('/api/stats/summary', async (_req, res) => {
 // this list. See readSessionMetas() / scan.ts.
 const WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
 
-app.get('/api/sessions', async (_req, res) => {
+app.get('/api/sessions', async (req, res) => {
   try {
+    const source = parseSource(req.query.source);
     const { events } = await getEvents();
     const { insights } = await getInsights();
     const sidecar = await readSessionMetas();
@@ -141,6 +147,7 @@ app.get('/api/sessions', async (_req, res) => {
     for (const sm of insights.sessionsMeta.values()) {
       if (sm.isSidechain || !sm.sessionId) continue; // skip subagent-only sessions
       if (sm.assistantMsgs === 0) continue;           // skip empty/aborted shells
+      if (source !== 'all' && sm.source !== source) continue; // surface filter
 
       const stats = eventStats.get(sm.sessionId);
       const agg = toolAgg.get(sm.sessionId);
@@ -155,6 +162,7 @@ app.get('/api/sessions', async (_req, res) => {
 
       result.push({
         session_id: sm.sessionId,
+        source: sm.source,
         project_path: sm.projectPath,
         start_time: new Date(sm.firstTs).toISOString(),
         duration_minutes: Math.max(0, Math.round((sm.lastTs - sm.firstTs) / 60000)),
@@ -181,14 +189,17 @@ app.get('/api/sessions', async (_req, res) => {
 
     // Preserve older sessions whose transcripts are gone from disk but whose
     // sidecar metadata survives — append them so the list never regresses.
+    // Sidecars are Claude Code only, so skip them when scoped to Cowork.
     const liveIds = new Set(result.map((r) => r.session_id));
     for (const s of sidecar) {
+      if (source === 'cowork') break;
       if (liveIds.has(s.session_id)) continue;
       const stats = eventStats.get(s.session_id);
       const in_tok = s.input_tokens ?? 0;
       const out_tok = s.output_tokens ?? 0;
       result.push({
         session_id: s.session_id,
+        source: 'code' as const,
         project_path: s.project_path,
         start_time: s.start_time,
         duration_minutes: s.duration_minutes ?? 0,
@@ -220,6 +231,26 @@ app.get('/api/sessions', async (_req, res) => {
   }
 });
 
+// Reports which usage surfaces have local data. The frontend gates all Cowork
+// UI (source toggle, Sources card, ?source= params) on cowork.available so that
+// Code-only users see exactly the original dashboard.
+app.get('/api/sources', async (_req, res) => {
+  try {
+    const { events, computedAt } = await getEvents();
+    let codeN = 0, coworkN = 0, codeLast = 0, coworkLast = 0;
+    for (const e of events) {
+      if (e.source === 'cowork') { coworkN++; if (e.ts > coworkLast) coworkLast = e.ts; }
+      else { codeN++; if (e.ts > codeLast) codeLast = e.ts; }
+    }
+    res.json(wrap({
+      code: { events: codeN, lastTs: codeLast },
+      cowork: { available: coworkN > 0, events: coworkN, lastTs: coworkLast },
+    }, computedAt));
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
 app.get('/api/usage/live', async (_req, res) => {
   try {
     const liveUsage = await fetchLiveUsage();
@@ -234,7 +265,8 @@ app.get('/api/usage/recent', async (req, res) => {
   try {
     const hours = Math.max(1, Math.min(72, Number(req.query.hours ?? 12)));
     const { events, computedAt } = await getEvents();
-    res.json(wrap(buildRecent(events, Date.now(), hours), computedAt));
+    const scoped = filterSource(events, parseSource(req.query.source));
+    res.json(wrap(buildRecent(scoped, Date.now(), hours), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -244,7 +276,8 @@ app.get('/api/usage/weekly', async (req, res) => {
   try {
     const days = Math.max(7, Math.min(28, Number(req.query.days ?? 7)));
     const { events, computedAt } = await getEvents();
-    res.json(wrap(buildWeekly(events, Date.now(), days), computedAt));
+    const scoped = filterSource(events, parseSource(req.query.source));
+    res.json(wrap(buildWeekly(scoped, Date.now(), days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -254,7 +287,8 @@ app.get('/api/usage/models', async (req, res) => {
   try {
     const days = Math.max(1, Math.min(31, Number(req.query.days ?? 7)));
     const { events, computedAt } = await getEvents();
-    res.json(wrap(buildModels(events, Date.now(), days), computedAt));
+    const scoped = filterSource(events, parseSource(req.query.source));
+    res.json(wrap(buildModels(scoped, Date.now(), days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -264,8 +298,9 @@ app.get('/api/activity', async (req, res) => {
   try {
     const days = Math.max(7, Math.min(180, Number(req.query.days ?? 126)));
     const { events, computedAt } = await getEvents();
+    const scoped = filterSource(events, parseSource(req.query.source));
     const stats = await readStatsSummary();
-    res.json(wrap(buildActivity(events, Date.now(), days, stats), computedAt));
+    res.json(wrap(buildActivity(scoped, Date.now(), days, stats), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -275,7 +310,8 @@ app.get('/api/tools', async (req, res) => {
   try {
     const days = Math.max(1, Math.min(31, Number(req.query.days ?? 7)));
     const { events, computedAt } = await getEvents();
-    res.json(wrap(buildTools(events, Date.now(), days), computedAt));
+    const scoped = filterSource(events, parseSource(req.query.source));
+    res.json(wrap(buildTools(scoped, Date.now(), days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -285,7 +321,8 @@ app.get('/api/heatmap', async (req, res) => {
   try {
     const days = Math.max(7, Math.min(365, Number(req.query.days ?? 90)));
     const { events, computedAt } = await getEvents();
-    res.json(wrap(buildHourlyHeatmap(events, Date.now(), days), computedAt));
+    const scoped = filterSource(events, parseSource(req.query.source));
+    res.json(wrap(buildHourlyHeatmap(scoped, Date.now(), days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -295,7 +332,10 @@ app.get('/api/projects', async (req, res) => {
   try {
     const days = Math.max(7, Math.min(365, Number(req.query.days ?? 30)));
     const { events, computedAt } = await getEvents();
-    res.json(wrap(buildProjectStats(events, Date.now(), days), computedAt));
+    // buildProjectStats already drops cowork; the source filter keeps behavior
+    // consistent when the UI explicitly scopes to one surface.
+    const scoped = filterSource(events, parseSource(req.query.source));
+    res.json(wrap(buildProjectStats(scoped, Date.now(), days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -313,7 +353,8 @@ app.get('/api/insights/errors', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildErrors(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildErrors(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -323,7 +364,8 @@ app.get('/api/insights/retries', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildRetries(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildRetries(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -333,7 +375,8 @@ app.get('/api/insights/languages', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildLanguages(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildLanguages(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -343,7 +386,8 @@ app.get('/api/insights/branches', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildBranches(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildBranches(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -353,7 +397,8 @@ app.get('/api/insights/mcp', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildMcp(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildMcp(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -363,7 +408,8 @@ app.get('/api/insights/complexity', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildComplexity(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildComplexity(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -373,7 +419,8 @@ app.get('/api/insights/yield', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildYield(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildYield(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -383,7 +430,8 @@ app.get('/api/insights/rejections', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildRejections(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildRejections(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -393,7 +441,8 @@ app.get('/api/insights/subagents', async (req, res) => {
   try {
     const days = clampDays(req.query.days);
     const { insights, computedAt } = await getInsights();
-    res.json(wrap(buildSubagentStats(insights, days), computedAt));
+    const scoped = scopeInsights(insights, parseSource(req.query.source));
+    res.json(wrap(buildSubagentStats(scoped, days), computedAt));
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }
@@ -595,4 +644,10 @@ if (existsSync(distDir)) {
 
 app.listen(PORT, () => {
   console.log(`[server] listening on http://localhost:${PORT} (claudeDir=${claudeDir()})`);
+  // Prime the event + insights caches in the background so the first request
+  // (often /api/sessions, which needs both) doesn't pay the full cold-scan cost
+  // — that scan of ~100MB+ of JSONL can take several seconds. Errors are ignored;
+  // the endpoints will simply scan on demand if this fails.
+  void getEvents().catch(() => {});
+  void getInsights().catch(() => {});
 });

--- a/server/insights-scan.ts
+++ b/server/insights-scan.ts
@@ -10,7 +10,7 @@ import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
 import { estimateCost } from './pricing.ts';
-import { claudeDir } from './scan.ts';
+import { scanRoots, keepScanFile, type UsageSource } from './scan.ts';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -26,6 +26,7 @@ export interface ToolCallRecord {
   gitBranch: string;
   projectPath: string;
   id: string;
+  source: UsageSource;
 }
 
 export interface ToolResultRecord {
@@ -46,6 +47,7 @@ export interface TaskSpawnRecord {
   completed: boolean;
   gitBranch: string;
   projectPath: string;
+  source: UsageSource;
 }
 
 export interface SessionMetaRecord {
@@ -71,6 +73,7 @@ export interface SessionMetaRecord {
   cost: number;
   file: string;
   agentId?: string;
+  source: UsageSource; // 'code' = Claude Code CLI, 'cowork' = desktop local-agent mode
 }
 
 export interface InsightsData {
@@ -94,10 +97,6 @@ function decodeProjectPath(encoded: string): string {
   return '/' + encoded.replace(/--/g, '/');
 }
 
-function projectsDir(): string {
-  return join(claudeDir(), 'projects');
-}
-
 function num(v: unknown): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0;
 }
@@ -106,7 +105,7 @@ function num(v: unknown): number {
 // File listing (recursive, including subagent directories)
 // ---------------------------------------------------------------------------
 
-async function listAllJsonl(dir: string): Promise<string[]> {
+async function listAllJsonl(dir: string, source: UsageSource = 'code'): Promise<string[]> {
   let entries: string[] = [];
   let dirents;
   try {
@@ -117,21 +116,29 @@ async function listAllJsonl(dir: string): Promise<string[]> {
   for (const d of dirents) {
     const full = join(dir, d.name);
     if (d.isDirectory()) {
-      entries = entries.concat(await listAllJsonl(full));
-    } else if (d.isFile() && d.name.endsWith('.jsonl')) {
+      entries = entries.concat(await listAllJsonl(full, source));
+    } else if (d.isFile() && d.name.endsWith('.jsonl') && keepScanFile(full, source)) {
       entries.push(full);
     }
   }
   return entries;
 }
 
+/** Every scanned jsonl file paired with its source, across all scan roots. */
+async function listAllRootFiles(): Promise<{ file: string; source: UsageSource }[]> {
+  const perRoot = await Promise.all(
+    scanRoots().map(async (r) => (await listAllJsonl(r.dir, r.source)).map((file) => ({ file, source: r.source })))
+  );
+  return perRoot.flat();
+}
+
 export async function projectsFingerprint(): Promise<number> {
-  const files = await listAllJsonl(projectsDir());
+  const files = await listAllRootFiles();
   let newest = 0;
   await Promise.all(
-    files.map(async (f) => {
+    files.map(async ({ file }) => {
       try {
-        const s = await stat(f);
+        const s = await stat(file);
         if (s.mtimeMs > newest) newest = s.mtimeMs;
       } catch { /* ignore */ }
     })
@@ -211,7 +218,7 @@ function isGitPushCommand(toolName: string, input: any): boolean {
 // ---------------------------------------------------------------------------
 
 export async function scanInsights(): Promise<InsightsData> {
-  const files = await listAllJsonl(projectsDir());
+  const files = await listAllRootFiles();
 
   const toolCalls: ToolCallRecord[] = [];
   // Map tool_use_id → ToolResultRecord
@@ -226,14 +233,16 @@ export async function scanInsights(): Promise<InsightsData> {
   const pendingGitCommits = new Map<string, string>();
   const pendingGitPushes = new Map<string, string>();
 
-  for (const file of files) {
+  for (const { file, source } of files) {
     // Skip files > 5MB
     try {
       const st = await stat(file);
       if (st.size > 5 * 1024 * 1024) continue;
     } catch { continue; }
 
-    const projectPath = projectPathFromFile(file);
+    // Cowork transcripts encode a sandbox-internal path that is meaningless on the
+    // host, so leave it empty (keeps cowork sessions out of the Projects tab).
+    const projectPath = source === 'cowork' ? '' : projectPathFromFile(file);
     const agentId = agentIdFromFileName(file);
     // Determine isSidechain from file path: subagent files are under a "subagents/" dir.
     // This is more reliable than the per-entry flag because all entries in a subagent file
@@ -282,6 +291,7 @@ export async function scanInsights(): Promise<InsightsData> {
           cost: 0,
           file,
           agentId,
+          source,
         };
         sessionsMeta.set(sessionId, sm);
       } else if (!fileIsSidechain && sm.isSidechain) {
@@ -464,6 +474,7 @@ export async function scanInsights(): Promise<InsightsData> {
               gitBranch,
               projectPath,
               id: toolId,
+              source,
             });
 
             // Task/Agent spawn detection
@@ -483,6 +494,7 @@ export async function scanInsights(): Promise<InsightsData> {
                 completed: false,
                 gitBranch,
                 projectPath,
+                source,
               });
 
               sm.subagentSpawns++;

--- a/server/insights.ts
+++ b/server/insights.ts
@@ -5,9 +5,31 @@
  */
 
 import type { InsightsData, ToolCallRecord, ToolResultRecord } from './insights-scan.ts';
+import type { UsageSource } from './scan.ts';
 import { estimateCost } from './pricing.ts';
 
 const DAY_MS = 24 * 3600_000;
+
+/**
+ * Narrow InsightsData to a single surface so the Insights tab honors the
+ * Code/Cowork toggle. Filters tool calls, task spawns and session metadata by
+ * `source`; `toolResults` (keyed by tool_use_id) and `searchCorpus` are left
+ * whole — builders join them via the already-filtered tool calls / sessions,
+ * so leftover entries are simply never looked up. 'all' is a pass-through.
+ */
+export function scopeInsights(d: InsightsData, source: 'all' | UsageSource): InsightsData {
+  if (source === 'all') return d;
+  const sessionsMeta = new Map(
+    [...d.sessionsMeta].filter(([, sm]) => sm.source === source)
+  );
+  return {
+    toolCalls: d.toolCalls.filter((tc) => tc.source === source),
+    toolResults: d.toolResults,
+    taskSpawns: d.taskSpawns.filter((t) => t.source === source),
+    sessionsMeta,
+    searchCorpus: d.searchCorpus,
+  };
+}
 
 function cutoff(days: number, now = Date.now()): number {
   return now - days * DAY_MS;
@@ -242,25 +264,33 @@ export function buildLanguages(d: InsightsData, days: number, now = Date.now()) 
 
 export function buildBranches(d: InsightsData, days: number, now = Date.now()) {
   const from = cutoff(days, now);
-  const branchMap = new Map<string, { effectiveTokens: number; cost: number; sessions: Set<string> }>();
+  // Key by repo + branch so the same branch name (e.g. "main") in different repos
+  // stays separate and each row can be attributed to its repository.
+  const branchMap = new Map<string, { branch: string; repo: string; effectiveTokens: number; cost: number; sessions: Set<string> }>();
 
   for (const sm of d.sessionsMeta.values()) {
     if (sm.lastTs < from) continue;
     if (!sm.gitBranch) continue;
 
-    let entry = branchMap.get(sm.gitBranch);
+    const repo = sm.projectPath
+      ? sm.projectPath.split(/[\\/]/).filter(Boolean).pop() ?? sm.projectPath
+      : 'unknown';
+    const key = `${repo} ${sm.gitBranch}`;
+
+    let entry = branchMap.get(key);
     if (!entry) {
-      entry = { effectiveTokens: 0, cost: 0, sessions: new Set() };
-      branchMap.set(sm.gitBranch, entry);
+      entry = { branch: sm.gitBranch, repo, effectiveTokens: 0, cost: 0, sessions: new Set() };
+      branchMap.set(key, entry);
     }
     entry.effectiveTokens += sm.effectiveTokens;
     entry.cost += sm.cost;
     entry.sessions.add(sm.sessionId);
   }
 
-  return [...branchMap.entries()]
-    .map(([branch, v]) => ({
-      branch,
+  return [...branchMap.values()]
+    .map((v) => ({
+      branch: v.branch,
+      repo: v.repo,
       effectiveTokens: v.effectiveTokens,
       cost: v.cost,
       sessions: v.sessions.size,

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -1,8 +1,10 @@
 import { createReadStream } from 'node:fs';
 import { readdir, stat, readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
+
+export type UsageSource = 'code' | 'cowork';
 
 export interface UsageEvent {
   ts: number; // epoch ms
@@ -15,6 +17,7 @@ export interface UsageEvent {
   tools: string[]; // tool_use names invoked in this assistant message
   projectPath: string; // decoded path of the project directory
   gitBranch: string; // git branch at the time of the message ('' if unknown)
+  source: UsageSource; // 'code' = Claude Code CLI, 'cowork' = desktop local-agent mode
 }
 
 export function claudeDir(): string {
@@ -25,7 +28,57 @@ function projectsDir(): string {
   return join(claudeDir(), 'projects');
 }
 
-async function listJsonl(dir: string): Promise<string[]> {
+/**
+ * Claude Cowork ("local agent mode" in the desktop app) writes standard Claude
+ * Code JSONL transcripts under
+ *   <coworkDir>/<acct>/<profile>/<sessionId>/.claude/projects/**\/*.jsonl
+ * The desktop-app data root differs per OS. `COWORK_DIR` overrides it (used by
+ * the Docker mount). Returns '' when no plausible default exists.
+ */
+function coworkDir(): string {
+  if (process.env.COWORK_DIR) return process.env.COWORK_DIR;
+  const home = homedir();
+  switch (platform()) {
+    case 'win32': {
+      const appData = process.env.APPDATA || join(home, 'AppData', 'Roaming');
+      return join(appData, 'Claude', 'local-agent-mode-sessions');
+    }
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', 'Claude', 'local-agent-mode-sessions');
+    default:
+      return join(home, '.config', 'Claude', 'local-agent-mode-sessions');
+  }
+}
+
+export interface ScanRoot {
+  dir: string;
+  source: UsageSource;
+}
+
+/**
+ * The directories scanned for usage events. Always the Claude Code projects dir;
+ * plus the Cowork desktop root when it exists on disk. Both the main scanner and
+ * the insights scanner walk this same list so the two stay in sync.
+ */
+export function scanRoots(): ScanRoot[] {
+  const roots: ScanRoot[] = [{ dir: projectsDir(), source: 'code' }];
+  const cw = coworkDir();
+  if (cw) roots.push({ dir: cw, source: 'cowork' });
+  return roots;
+}
+
+/**
+ * Cowork roots contain metadata (`local_*.json`), audit logs (`audit.jsonl`) and
+ * the nested `.claude/projects/` transcripts. Only the latter carry token usage,
+ * so cowork files are kept only when their path sits under a `.claude/projects/`
+ * segment. Code files are always kept.
+ */
+export function keepScanFile(file: string, source: UsageSource): boolean {
+  if (source === 'code') return true;
+  return /[\\/]\.claude[\\/]projects[\\/]/.test(file);
+}
+
+async function listJsonl(dir: string, source: UsageSource = 'code'): Promise<string[]> {
   let entries: string[] = [];
   let dirents;
   try {
@@ -36,17 +89,18 @@ async function listJsonl(dir: string): Promise<string[]> {
   for (const d of dirents) {
     const full = join(dir, d.name);
     if (d.isDirectory()) {
-      entries = entries.concat(await listJsonl(full));
-    } else if (d.isFile() && d.name.endsWith('.jsonl')) {
+      entries = entries.concat(await listJsonl(full, source));
+    } else if (d.isFile() && d.name.endsWith('.jsonl') && keepScanFile(full, source)) {
       entries.push(full);
     }
   }
   return entries;
 }
 
-/** Newest mtime across all jsonl files — used as a cheap cache-invalidation signal. */
+/** Newest mtime across all scanned jsonl files — a cheap cache-invalidation signal. */
 export async function projectsFingerprint(): Promise<number> {
-  const files = await listJsonl(projectsDir());
+  const fileLists = await Promise.all(scanRoots().map((r) => listJsonl(r.dir, r.source)));
+  const files = fileLists.flat();
   let newest = 0;
   await Promise.all(
     files.map(async (f) => {
@@ -69,15 +123,20 @@ async function parseFile(
   file: string,
   seen: Map<string, number>,
   out: UsageEvent[],
-  sessionPathMap?: Map<string, string>
+  sessionPathMap?: Map<string, string>,
+  source: UsageSource = 'code'
 ): Promise<void> {
   // Derive the OS path from the JSONL file path.
   // Claude encodes project dirs as: <drive-letter>--<path-segments-joined-by-->
   // e.g.  E--dev-projects-claude-dashboard  →  e:\dev-projects\claude-dashboard
   //       C--Users-Iftah-Saar-Desktop--Dev-Projects-my-landing-page-2026  →  c:\...
   // Rule: '--' is the OS path separator; single '-' stays as a literal dash.
+  // Cowork transcripts encode a sandbox-internal path that is meaningless on the
+  // host, so we leave projectPath empty for them (keeps them out of the Projects tab).
   let projectPath = '';
-  try {
+  if (source === 'cowork') {
+    // skip decoding — sandbox path is not a real host project
+  } else try {
     const parts = file.replace(/\\/g, '/').split('/');
     const projIdx = parts.lastIndexOf('projects');
     if (projIdx !== -1 && parts[projIdx + 1]) {
@@ -124,7 +183,9 @@ async function parseFile(
     }
 
     const sessionId = obj.sessionId ?? obj.session_id ?? '';
-    const resolvedProjectPath = (sessionPathMap && sessionId) ? (sessionPathMap.get(sessionId) ?? projectPath) : projectPath;
+    const resolvedProjectPath = (source === 'code' && sessionPathMap && sessionId)
+      ? (sessionPathMap.get(sessionId) ?? projectPath)
+      : projectPath;
     const gitBranch: string = typeof obj.gitBranch === 'string' ? obj.gitBranch : '';
 
     const event: UsageEvent = {
@@ -138,6 +199,7 @@ async function parseFile(
       tools,
       projectPath: resolvedProjectPath,
       gitBranch,
+      source,
     };
 
     // Dedup: same logical response can appear multiple times (retries/streaming).
@@ -169,11 +231,16 @@ export async function scanEvents(): Promise<UsageEvent[]> {
     }
   }
 
-  const files = await listJsonl(projectsDir());
+  // Shared dedup map across all roots: a session's cliSessionId can write to both
+  // the global projects dir and a cowork root, and the requestId:message.id key
+  // collapses those into one event regardless of which root it came from.
   const seen = new Map<string, number>();
   const out: UsageEvent[] = [];
-  for (const f of files) {
-    await parseFile(f, seen, out, sessionPathMap);
+  for (const root of scanRoots()) {
+    const files = await listJsonl(root.dir, root.source);
+    for (const f of files) {
+      await parseFile(f, seen, out, sessionPathMap, root.source);
+    }
   }
   out.sort((a, b) => a.ts - b.ts);
   return out;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { usePolling } from './hooks/usePolling';
 import { useLimits } from './hooks/useLimits';
-import type { ActivityData, ModelsData, RecentData, WeeklyData, ToolsData, ClaudeConfig, SessionMeta, LiveUsageData, HeatmapData, ProjectData, InsightsErrors, InsightsRetries, InsightsLanguages, InsightsBranches, InsightsMcp, ComplexityPoint, InsightsYield, InsightsRejections, SubagentStats, LiveSubagents, VersionInfo } from './types';
+import type { ActivityData, ModelsData, RecentData, WeeklyData, ToolsData, ClaudeConfig, SessionMeta, LiveUsageData, HeatmapData, ProjectData, InsightsErrors, InsightsRetries, InsightsLanguages, InsightsBranches, InsightsMcp, ComplexityPoint, InsightsYield, InsightsRejections, SubagentStats, LiveSubagents, VersionInfo, SourcesInfo, UsageSource } from './types';
 import { StatCard } from './components/design-system/atoms/StatCard/StatCard';
 import { BlockGauge } from './components/design-system/organisms/BlockGauge/BlockGauge';
 import { UsageBarChart } from './components/design-system/organisms/UsageBarChart/UsageBarChart';
@@ -24,6 +24,7 @@ import { OfflineBanner } from './components/design-system/molecules/OfflineBanne
 import { UpdateBanner } from './components/design-system/molecules/UpdateBanner/UpdateBanner';
 import { SpendingLimits } from './components/design-system/molecules/SpendingLimits/SpendingLimits';
 import { ToggleGroup } from './components/design-system/atoms/ToggleGroup/ToggleGroup';
+import { LegendDot } from './components/design-system/atoms/LegendDot/LegendDot';
 import { ErrorBreakdown } from './components/design-system/organisms/ErrorBreakdown/ErrorBreakdown';
 import { LanguageBreakdown } from './components/design-system/organisms/LanguageBreakdown/LanguageBreakdown';
 import { BranchBreakdown } from './components/design-system/organisms/BranchBreakdown/BranchBreakdown';
@@ -65,6 +66,16 @@ const INSIGHT_DAY_OPTIONS: { value: InsightDays; label: string }[] = [
   { value: '30', label: '30d' },
 ];
 
+// Source filter (Code = Claude Code CLI, Cowork = desktop local-agent mode).
+// Only surfaced when the user actually has Cowork data on disk.
+type SourceFilter = 'all' | UsageSource;
+const SOURCE_OPTIONS: { value: SourceFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'code', label: 'Code' },
+  { value: 'cowork', label: 'Cowork' },
+];
+const SOURCE_COLOR: Record<UsageSource, string> = { code: '#d97757', cowork: '#6366f1' };
+
 export default function App() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -73,16 +84,33 @@ export default function App() {
   const [weekDays, setWeekDays] = useState(7);
   const [recentHours, setRecentHours] = useState(12);
   const [dailyMetric, setDailyMetric] = useState<'tokens' | 'cost'>('tokens');
-  const recent = usePolling<RecentData>(`/api/usage/recent?hours=${recentHours}`, POLL);
-  const weekly = usePolling<WeeklyData>(`/api/usage/weekly?days=${weekDays}`, POLL);
-  const models = usePolling<ModelsData>('/api/usage/models?days=7', POLL);
-  const activity = usePolling<ActivityData>('/api/activity', 30000);
-  const tools = usePolling<ToolsData>('/api/tools?days=7', 30000);
+
+  // Cowork detection — fetched first; gates every Cowork affordance below so that
+  // Code-only users get the original dashboard byte-for-byte.
+  const sourcesInfo = usePolling<SourcesInfo>('/api/sources', 60000);
+  const coworkAvailable = !!sourcesInfo.data?.cowork.available;
+  const [source, setSource] = useState<SourceFilter>('all');
+  // If Cowork data disappears (or never existed), never leave a stale scoped filter.
+  useEffect(() => {
+    if (!coworkAvailable && source !== 'all') setSource('all');
+  }, [coworkAvailable, source]);
+  // Append ?source= only when Cowork data exists and a surface is selected; otherwise
+  // the URL is identical to before this feature (no refetch churn, no behavior change).
+  const withSrc = (url: string) =>
+    coworkAvailable && source !== 'all'
+      ? url + (url.includes('?') ? '&' : '?') + `source=${source}`
+      : url;
+
+  const recent = usePolling<RecentData>(withSrc(`/api/usage/recent?hours=${recentHours}`), POLL);
+  const weekly = usePolling<WeeklyData>(withSrc(`/api/usage/weekly?days=${weekDays}`), POLL);
+  const models = usePolling<ModelsData>(withSrc('/api/usage/models?days=7'), POLL);
+  const activity = usePolling<ActivityData>(withSrc('/api/activity'), 30000);
+  const tools = usePolling<ToolsData>(withSrc('/api/tools?days=7'), 30000);
   const config = usePolling<ClaudeConfig>('/api/config', 60000);
-  const sessions = usePolling<SessionMeta[]>('/api/sessions', 10000);
+  const sessions = usePolling<SessionMeta[]>(withSrc('/api/sessions'), 10000);
   const liveUsage = usePolling<LiveUsageData>('/api/usage/live', 15000);
-  const heatmap = usePolling<HeatmapData>('/api/heatmap?days=90', 60000);
-  const projectCosts = usePolling<ProjectData>('/api/projects?days=90', 30000);
+  const heatmap = usePolling<HeatmapData>(withSrc('/api/heatmap?days=90'), 60000);
+  const projectCosts = usePolling<ProjectData>(withSrc('/api/projects?days=90'), 30000);
   const liveSubagents = usePolling<LiveSubagents>('/api/subagents/live', 4000);
   const version = usePolling<VersionInfo>('/api/version', 1_800_000);
   const [limits, setLimits] = useLimits();
@@ -91,15 +119,15 @@ export default function App() {
   // Insights tab state
   const [insightDays, setInsightDays] = useState<InsightDays>('7');
   const insightDaysNum = insightDays;
-  const insightErrors = usePolling<InsightsErrors>(`/api/insights/errors?days=${insightDaysNum}`, 60000);
-  const insightRetries = usePolling<InsightsRetries>(`/api/insights/retries?days=${insightDaysNum}`, 60000);
-  const insightLanguages = usePolling<InsightsLanguages[]>(`/api/insights/languages?days=${insightDaysNum}`, 60000);
-  const insightBranches = usePolling<InsightsBranches[]>(`/api/insights/branches?days=${insightDaysNum}`, 60000);
-  const insightMcp = usePolling<InsightsMcp>(`/api/insights/mcp?days=${insightDaysNum}`, 60000);
-  const insightComplexity = usePolling<ComplexityPoint[]>(`/api/insights/complexity?days=${insightDaysNum}`, 60000);
-  const insightYield = usePolling<InsightsYield>(`/api/insights/yield?days=${insightDaysNum}`, 60000);
-  const insightRejections = usePolling<InsightsRejections>(`/api/insights/rejections?days=${insightDaysNum}`, 60000);
-  const insightSubagents = usePolling<SubagentStats>(`/api/insights/subagents?days=${insightDaysNum}`, 60000);
+  const insightErrors = usePolling<InsightsErrors>(withSrc(`/api/insights/errors?days=${insightDaysNum}`), 60000);
+  const insightRetries = usePolling<InsightsRetries>(withSrc(`/api/insights/retries?days=${insightDaysNum}`), 60000);
+  const insightLanguages = usePolling<InsightsLanguages[]>(withSrc(`/api/insights/languages?days=${insightDaysNum}`), 60000);
+  const insightBranches = usePolling<InsightsBranches[]>(withSrc(`/api/insights/branches?days=${insightDaysNum}`), 60000);
+  const insightMcp = usePolling<InsightsMcp>(withSrc(`/api/insights/mcp?days=${insightDaysNum}`), 60000);
+  const insightComplexity = usePolling<ComplexityPoint[]>(withSrc(`/api/insights/complexity?days=${insightDaysNum}`), 60000);
+  const insightYield = usePolling<InsightsYield>(withSrc(`/api/insights/yield?days=${insightDaysNum}`), 60000);
+  const insightRejections = usePolling<InsightsRejections>(withSrc(`/api/insights/rejections?days=${insightDaysNum}`), 60000);
+  const insightSubagents = usePolling<SubagentStats>(withSrc(`/api/insights/subagents?days=${insightDaysNum}`), 60000);
 
   const error = recent.error || weekly.error;
   const empty =
@@ -149,6 +177,12 @@ export default function App() {
           </p>
         </div>
         <div className="flex items-center gap-4">
+          {coworkAvailable && (
+            <div className="flex items-center gap-2" title="Filter usage by surface: Claude Code CLI vs Cowork (desktop local-agent mode)">
+              <span className="text-[11px] uppercase tracking-wide text-zinc-600">source</span>
+              <ToggleGroup<SourceFilter> options={SOURCE_OPTIONS} value={source} onChange={setSource} />
+            </div>
+          )}
           <button
             onClick={() => setShowLimits((v) => !v)}
             className="rounded-lg px-3 py-1.5 text-xs text-zinc-400 ring-1 ring-white/10 hover:text-zinc-200"
@@ -209,6 +243,7 @@ export default function App() {
                 <div className="flex flex-col lg:col-span-2">
                   <Section
                     title={`Last ${recentHours} hours · hourly tokens by model`}
+                    help="Tokens used per hour over the recent window, stacked by model. Use the buttons on the right to change the window (5–48h)."
                     right={
                       <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
                         {[5, 12, 24, 48].map((h) => (
@@ -272,6 +307,7 @@ export default function App() {
                       label={`Est. equivalent cost · ${weekDays}d`}
                       value={usd(weekly.data?.totals.cost ?? 0)}
                       sub={topModel ? `top: ${shortModel(topModel.model)}` : undefined}
+                      help="What this usage would cost at Anthropic's pay-as-you-go API rates. Your subscription has no per-token bill — this is a reference figure only."
                     />
                     <StatCard
                       label={`Effective tokens · last ${weekDays} days`}
@@ -281,21 +317,51 @@ export default function App() {
                           ? `${weekDays === 7 ? 'prev week' : `prev ${weekDays / 7} weeks`}: ${compact(prevWeeklyEffective)}`
                           : `${compact(weekly.data?.totals.outputTokens ?? 0)} output`
                       }
+                      help="Input + output + cache-write tokens — the tokens that count toward rate limits. Cheap cache reads are excluded. Compared against the previous period."
                     />
                     <StatCard
                       label="Cost per day (avg)"
                       value={usd(costPerDay)}
                       sub={`over ${weekDays} days`}
+                      help="Estimated equivalent API cost averaged over the selected window (total cost ÷ days)."
                     />
                     <StatCard
                       label="Projected this month"
                       value={usd(projectedMonthCost)}
                       sub={`${daysLeftInMonth}d left in month`}
                       accent="#6366f1"
+                      help="Estimated month-end equivalent cost if your current average daily spend continues for the rest of the calendar month."
                     />
                   </>
                 )}
               </div>
+
+              {/* Sources split (Code vs Cowork) — only under the All filter, where
+                  the split is meaningful (a single-surface filter zeroes the other). */}
+              {coworkAvailable && source === 'all' && weekly.data?.bySource && (() => {
+                const bs = weekly.data.bySource;
+                const codeEff = bs.code.effectiveTokens;
+                const coworkEff = bs.cowork.effectiveTokens;
+                const total = codeEff + coworkEff;
+                const codePct = total > 0 ? (codeEff / total) * 100 : 0;
+                return (
+                  <Section
+                    title={`Sources · effective tokens · ${weekDays}d`}
+                    help="Split of effective tokens (and equivalent cost) between Claude Code (CLI) and Cowork (desktop local-agent mode) over the selected window."
+                  >
+                    <div className="flex items-center gap-4">
+                      <div className="flex flex-1 h-3 overflow-hidden rounded-full bg-ink-800 ring-1 ring-white/5">
+                        <div style={{ width: `${codePct}%`, backgroundColor: SOURCE_COLOR.code }} />
+                        <div style={{ width: `${100 - codePct}%`, backgroundColor: SOURCE_COLOR.cowork }} />
+                      </div>
+                      <div className="flex items-center gap-4">
+                        <LegendDot color={SOURCE_COLOR.code} label={`Code · ${compact(codeEff)} · ${usd(bs.code.cost)}`} />
+                        <LegendDot color={SOURCE_COLOR.cowork} label={`Cowork · ${compact(coworkEff)} · ${usd(bs.cowork.cost)}`} />
+                      </div>
+                    </div>
+                  </Section>
+                );
+              })()}
 
               {/* Daily chart with projection */}
               {(() => {
@@ -310,6 +376,7 @@ export default function App() {
                 return (
                   <Section
                     title={`Last ${weekDays} days · daily ${dailyMetric} by model`}
+                    help="Daily tokens (or equivalent cost), stacked by model. The dotted segment past today is a projection from your recent daily average. Toggle tokens/cost and the window on the right."
                     right={
                       <div className="flex items-center gap-3">
                         {delta !== null && (
@@ -382,13 +449,19 @@ export default function App() {
 
               {/* Cache efficiency chart */}
               {weekly.data?.cacheEfficiency && weekly.data.cacheEfficiency.length > 0 && (
-                <Section title="Cache efficiency · hit rate over time">
+                <Section
+                  title="Cache efficiency · hit rate over time"
+                  help="Share of total tokens served from the prompt cache each day (cache reads ÷ all tokens). Higher means more context was reused cheaply instead of re-sent."
+                >
                   <CacheEfficiencyChart data={weekly.data.cacheEfficiency} />
                 </Section>
               )}
 
               {/* Peak hours heatmap */}
-              <Section title="Peak usage · tokens by hour & day of week">
+              <Section
+                title="Peak usage · tokens by hour & day of week"
+                help="Effective tokens summed into a 7-day × 24-hour grid (your local time). Darker cells are your busiest hours — when you use Claude most."
+              >
                 {heatmap.data ? (
                   <PeakHoursHeatmap grid={heatmap.data.grid} />
                 ) : heatmap.loading ? (
@@ -399,7 +472,10 @@ export default function App() {
               </Section>
 
               {/* Activity heatmap */}
-              <Section title="Daily activity · last 18 weeks">
+              <Section
+                title="Daily activity · last 18 weeks"
+                help="GitHub-style calendar: one square per day, darker = more effective tokens used. Shows your day-to-day usage streaks over the last ~18 weeks."
+              >
                 {activity.data ? (
                   <ActivityHeatmap days={activity.data.dailyActivity} />
                 ) : activity.loading ? (
@@ -413,14 +489,20 @@ export default function App() {
           {activeTab === 'models' && (
             <>
               <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-                <Section title="Model breakdown · 7d">
+                <Section
+                  title="Model breakdown · 7d"
+                  help="Share of effective tokens by model over the last 7 days, with each model's cost per 1M effective tokens. Shows which models your usage leans on."
+                >
                   {models.data ? (
                     <ModelBreakdown models={models.data.models} />
                   ) : models.loading ? (
                     <DonutSkeleton />
                   ) : null}
                 </Section>
-                <Section title="Tool usage · 7d">
+                <Section
+                  title="Tool usage · 7d"
+                  help="How many times each tool was invoked over the last 7 days, ranked. Reflects which tools the work relied on most."
+                >
                   {tools.data ? (
                     <ToolUsage tools={tools.data.tools} totalCalls={tools.data.totalCalls} />
                   ) : tools.loading ? (
@@ -460,6 +542,7 @@ export default function App() {
                       : 'loading…'
                   }
                   accent="#f87171"
+                  help="Share of tool calls in this window that failed or were rejected (error result returned). Lower is better."
                 />
                 <StatCard
                   label="One-shot rate"
@@ -473,6 +556,7 @@ export default function App() {
                       ? `${insightRetries.data.retried} retried edits`
                       : 'loading…'
                   }
+                  help="Share of Edit/Write calls that succeeded on the first try (no follow-up retry on the same file). Higher means cleaner edits."
                 />
                 <StatCard
                   label="Delegation rate"
@@ -486,6 +570,7 @@ export default function App() {
                       ? `${insightSubagents.data.spawns} subagent spawns`
                       : 'loading…'
                   }
+                  help="Share of sessions that spawned at least one subagent (Task/Agent tool). Indicates how often work is delegated to subagents."
                 />
                 <StatCard
                   label="Wasted tokens"
@@ -500,51 +585,79 @@ export default function App() {
                       : 'loading…'
                   }
                   accent="#f59e0b"
+                  help="Estimated tokens spent on edits that errored and had to be retried — approximated from each session's average tokens-per-turn. A rough waste indicator."
                 />
               </div>
 
               {/* Tool errors — full width */}
-              <Section title="Tool errors · failure analysis">
+              <Section
+                title="Tool errors · failure analysis"
+                help="Failed/rejected tool calls in this window, grouped by error category (left) and by tool (right). The line shows errors per day. Percentages are each tool's own error rate."
+              >
                 <ErrorBreakdown data={insightErrors.data} />
               </Section>
 
               {/* Languages | Branches */}
               <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-                <Section title="Languages · edits by file type">
+                <Section
+                  title="Languages · edits by file type"
+                  help="Files touched in this window, bucketed by extension into a language. Solid = edits/writes; dimmed = reads. Shows what kinds of files the work concentrated on."
+                >
                   <LanguageBreakdown data={insightLanguages.data} />
                 </Section>
-                <Section title="Branches · token usage by git branch">
+                <Section
+                  title="Branches · token usage by git branch"
+                  help="Effective tokens, cost and session count attributed to each git branch (shown as repo / branch). Reflects which branches the most work went into."
+                >
                   <BranchBreakdown data={insightBranches.data} />
                 </Section>
               </div>
 
               {/* MCP | Rejections */}
               <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-                <Section title="MCP vs built-in · tool call split">
+                <Section
+                  title="MCP vs built-in · tool call split"
+                  help="How tool calls split between Claude's built-in tools and tools from connected MCP servers. The per-server table lists call counts and how many failed (errors), one row per MCP server."
+                >
                   <McpBreakdown data={insightMcp.data} />
                 </Section>
-                <Section title="Permission rejections · by tool">
+                <Section
+                  title="Permission rejections · by tool"
+                  help="Tool calls you declined when Claude asked for permission, grouped by tool. High counts flag tools Claude reaches for that you often block."
+                >
                   <RejectionsPanel data={insightRejections.data} />
                 </Section>
               </div>
 
               {/* Complexity scatter — full width */}
-              <Section title="Session complexity · tool calls vs tokens (dot size = subagents)">
+              <Section
+                title="Session complexity · tool calls vs tokens (dot size = subagents)"
+                help="One dot per session: x = number of tool calls, y = effective tokens, dot size = subagents spawned. Dots to the upper-right are the heaviest, most complex sessions."
+              >
                 <ComplexityScatter data={insightComplexity.data} />
               </Section>
 
               {/* Yield | Subagent stats */}
               <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-                <Section title="Yield · committed vs uncommitted sessions">
+                <Section
+                  title="Yield · committed vs uncommitted sessions"
+                  help="Sessions that ran a git commit vs those that didn't — a rough proxy for which work landed. Lists the biggest uncommitted sessions by tokens."
+                >
                   <YieldPanel data={insightYield.data} />
                 </Section>
-                <Section title="Subagent stats · delegation analysis">
+                <Section
+                  title="Subagent stats · delegation analysis"
+                  help="Subagent (Task/Agent) spawns in this window: total, average per delegating session, and breakdowns by subagent type and model."
+                >
                   <SubagentStatsPanel data={insightSubagents.data} />
                 </Section>
               </div>
 
               {/* Retry panel — standalone */}
-              <Section title="Edit retries · one-shot analysis">
+              <Section
+                title="Edit retries · one-shot analysis"
+                help="Edit/Write calls that succeeded first try vs those retried after an error, with the estimated tokens and cost wasted on the retries."
+              >
                 <RetryPanel data={insightRetries.data} />
               </Section>
             </>
@@ -553,30 +666,35 @@ export default function App() {
           {/* ── SESSIONS TAB ── */}
           {activeTab === 'sessions' && (
             <>
-              <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-                <div className="lg:col-span-1 self-start">
-                  {config.data ? (
-                    <ConfigProfile config={config.data} />
-                  ) : config.loading ? (
-                    <div className="card p-5 flex items-center justify-center min-h-[200px]">
-                      <Skeleton className="h-full w-full rounded-2xl" />
-                    </div>
-                  ) : null}
+              {/* Config profile + per-project breakdown only make sense for Code.
+                  Cowork sessions run in a sandbox with no host project, so under
+                  the Cowork filter we skip straight to the session log. */}
+              {source !== 'cowork' && (
+                <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+                  <div className="lg:col-span-1 self-start">
+                    {config.data ? (
+                      <ConfigProfile config={config.data} />
+                    ) : config.loading ? (
+                      <div className="card p-5">
+                        <Skeleton className="h-[200px] w-full rounded-2xl" />
+                      </div>
+                    ) : null}
+                  </div>
+                  <div className="lg:col-span-2">
+                    {sessions.data ? (
+                      <ProjectBreakdown
+                        sessions={sessions.data}
+                        periodDays={totalPeriodDays}
+                        projectCosts={projectCosts.data?.projects}
+                      />
+                    ) : sessions.loading ? (
+                      <div className="card p-5">
+                        <Skeleton className="h-[200px] w-full rounded-2xl" />
+                      </div>
+                    ) : null}
+                  </div>
                 </div>
-                <div className="lg:col-span-2">
-                  {sessions.data ? (
-                    <ProjectBreakdown
-                      sessions={sessions.data}
-                      periodDays={totalPeriodDays}
-                      projectCosts={projectCosts.data?.projects}
-                    />
-                  ) : sessions.loading ? (
-                    <div className="card p-5 flex items-center justify-center min-h-[200px]">
-                      <Skeleton className="h-full w-full rounded-2xl" />
-                    </div>
-                  ) : null}
-                </div>
-              </div>
+              )}
 
               {sessions.data ? (
                 <SessionHistoryTable
@@ -585,8 +703,10 @@ export default function App() {
                   onExport={() => sessions.data ?? []}
                 />
               ) : sessions.loading ? (
-                <div className="card p-5 min-h-[150px] flex items-center justify-center">
-                  <Skeleton className="h-full w-full rounded-2xl" />
+                <div className="card p-5 space-y-3">
+                  <Skeleton className="h-5 w-48 rounded" />
+                  <Skeleton className="h-3 w-72 rounded" />
+                  <Skeleton className="mt-2 h-[280px] w-full rounded-2xl" />
                 </div>
               ) : null}
             </>

--- a/src/components/design-system/atoms/InfoTip/InfoTip.tsx
+++ b/src/components/design-system/atoms/InfoTip/InfoTip.tsx
@@ -1,0 +1,28 @@
+import type { InfoTipProps } from './types';
+
+/**
+ * A small "?" badge that reveals a wrapping explanation on hover. Pure CSS
+ * (group-hover), no state. `normal-case`/`font-normal` reset any uppercase/bold
+ * styling inherited from card headers or stat labels.
+ */
+export function InfoTip({ text, align = 'left' }: InfoTipProps) {
+  const horizontal =
+    align === 'right' ? 'right-0' : align === 'center' ? 'left-1/2 -translate-x-1/2' : 'left-0';
+
+  return (
+    <span className="group relative inline-flex shrink-0 align-middle">
+      <span
+        className="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-white/10 text-[10px] font-bold leading-none text-zinc-400 transition-colors group-hover:bg-white/20 group-hover:text-zinc-200"
+        aria-hidden="true"
+      >
+        ?
+      </span>
+      <span
+        role="tooltip"
+        className={`pointer-events-none invisible absolute top-6 ${horizontal} z-30 w-64 rounded-lg border border-white/10 bg-ink-700 px-3 py-2 text-left text-[11px] font-normal normal-case leading-relaxed tracking-normal text-zinc-300 opacity-0 shadow-xl transition-opacity duration-150 group-hover:visible group-hover:opacity-100`}
+      >
+        {text}
+      </span>
+    </span>
+  );
+}

--- a/src/components/design-system/atoms/InfoTip/types.ts
+++ b/src/components/design-system/atoms/InfoTip/types.ts
@@ -1,0 +1,8 @@
+import type { ReactNode } from 'react';
+
+export interface InfoTipProps {
+  /** Explanation shown on hover. */
+  text: ReactNode;
+  /** Horizontal anchor of the popover relative to the "?" badge. */
+  align?: 'left' | 'center' | 'right';
+}

--- a/src/components/design-system/atoms/StatCard/StatCard.tsx
+++ b/src/components/design-system/atoms/StatCard/StatCard.tsx
@@ -1,9 +1,13 @@
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { StatCardProps } from './types';
 
-export function StatCard({ label, value, sub, accent }: StatCardProps) {
+export function StatCard({ label, value, sub, accent, help }: StatCardProps) {
   return (
     <div className="card p-5">
-      <div className="text-xs uppercase tracking-wider text-zinc-500">{label}</div>
+      <div className="flex items-center gap-1.5 text-xs uppercase tracking-wider text-zinc-500">
+        {label}
+        {help && <InfoTip text={help} />}
+      </div>
       <div
         className="mt-2 text-3xl font-bold tabular-nums"
         style={accent ? { color: accent } : undefined}

--- a/src/components/design-system/atoms/StatCard/types.ts
+++ b/src/components/design-system/atoms/StatCard/types.ts
@@ -5,4 +5,6 @@ export interface StatCardProps {
   value: string;
   sub?: ReactNode;
   accent?: string;
+  /** Optional hover explanation shown via a "?" badge next to the label. */
+  help?: ReactNode;
 }

--- a/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
+++ b/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { formatRemainingHours, formatRemainingDays, blockBarColor } from './utils';
 import type { PlanUsageProps } from './types';
 
@@ -53,7 +54,10 @@ export function PlanUsage({ block, weekly, liveUsage }: PlanUsageProps) {
   return (
     <div className="card p-5 flex flex-col justify-between flex-none">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-bold uppercase tracking-wider text-zinc-300">Plan usage</h3>
+        <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
+          Plan usage
+          <InfoTip text="Your live subscription limits from Claude.ai: the 5-hour window plus the weekly all-models and Sonnet caps, each with % used and time to reset. Pulled from Anthropic's usage API." />
+        </h3>
         <span className="text-zinc-500 font-mono text-xs select-none">→</span>
       </div>
 

--- a/src/components/design-system/molecules/Section/Section.tsx
+++ b/src/components/design-system/molecules/Section/Section.tsx
@@ -1,10 +1,14 @@
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { SectionProps } from './types';
 
-export function Section({ title, children, right, className = '', grow = false }: SectionProps) {
+export function Section({ title, children, right, className = '', grow = false, help }: SectionProps) {
   return (
     <div className={`card p-5 ${grow ? 'flex flex-col h-full' : ''} ${className}`}>
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-zinc-300">{title}</h2>
+        <h2 className="flex items-center gap-1.5 text-sm font-semibold text-zinc-300">
+          {title}
+          {help && <InfoTip text={help} />}
+        </h2>
         {right}
       </div>
       <div className={grow ? 'flex-1 flex flex-col justify-end' : ''}>{children}</div>

--- a/src/components/design-system/molecules/Section/types.ts
+++ b/src/components/design-system/molecules/Section/types.ts
@@ -6,4 +6,6 @@ export interface SectionProps {
   right?: ReactNode;
   className?: string;
   grow?: boolean;
+  /** Optional hover explanation shown via a "?" badge next to the title. */
+  help?: ReactNode;
 }

--- a/src/components/design-system/molecules/SpendingLimits/SpendingLimits.tsx
+++ b/src/components/design-system/molecules/SpendingLimits/SpendingLimits.tsx
@@ -1,4 +1,5 @@
 import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { spendingBarColor } from './utils';
 import type { SpendingLimitsProps } from './types';
 
@@ -20,7 +21,10 @@ export function SpendingLimits({ limits, costPerDay }: SpendingLimitsProps) {
   return (
     <div className="card p-5">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-bold uppercase tracking-wider text-zinc-500">API Spending</h3>
+        <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-500">
+          API Spending
+          <InfoTip text="Your estimated equivalent API spend against the daily/weekly/monthly USD caps you set (⚙ limits). Caps are stored locally in your browser — this is a budgeting aid, not a real bill." />
+        </h3>
         <span className="text-xs text-zinc-600">estimated from local logs</span>
       </div>
       <div className="space-y-4">

--- a/src/components/design-system/organisms/AgentActivity/AgentActivity.tsx
+++ b/src/components/design-system/organisms/AgentActivity/AgentActivity.tsx
@@ -243,7 +243,10 @@ export function AgentActivity({ data, loading }: AgentActivityProps) {
   const orphanCompleted = completed.filter((c) => !mainKeys.has(c.parentKey));
 
   return (
-    <Section title="Agents · live activity">
+    <Section
+      title="Agents · live activity"
+      help="Live view of agents working right now: main agents, their running subagents (Task/Agent spawns), and recently finished ones — refreshed every few seconds from active session logs. Empty when nothing is running."
+    >
       {loading && !data ? (
         <div className="h-10 flex items-center text-xs text-zinc-600">Loading…</div>
       ) : hasActivity ? (

--- a/src/components/design-system/organisms/BlockGauge/BlockGauge.tsx
+++ b/src/components/design-system/organisms/BlockGauge/BlockGauge.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { compact } from '@/lib/format';
 import { useBlockAlerts } from '@/hooks/useBlockAlerts';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { BlockGaugeProps } from './types';
 import { BLOCK_MS, DEFAULT_BLOCK_LIMIT, formatRemaining } from './utils';
 
@@ -97,8 +98,12 @@ export function BlockGauge({ block, liveUsage }: BlockGaugeProps) {
   return (
     <div className="card flex flex-col items-center justify-center p-6">
       <div className="text-center">
-        <div className="text-xs uppercase tracking-wider text-zinc-500 font-bold">
+        <div className="flex items-center justify-center gap-1.5 text-xs uppercase tracking-wider text-zinc-500 font-bold">
           Claude Code · block usage
+          <InfoTip
+            align="center"
+            text="Your current 5-hour usage block, anchored to your most recent session's first message (how Anthropic starts a 5h window). The ring shows % of the live account limit from Claude.ai; rows below show this block's effective tokens, cache reads, reset time and burn rate."
+          />
         </div>
         {statusBadge}
       </div>

--- a/src/components/design-system/organisms/BranchBreakdown/BranchBreakdown.tsx
+++ b/src/components/design-system/organisms/BranchBreakdown/BranchBreakdown.tsx
@@ -27,13 +27,12 @@ export function BranchBreakdown({ data }: BranchBreakdownProps) {
   return (
     <div className="space-y-2.5">
       {data.map((b) => (
-        <div key={b.branch} className="space-y-1">
+        <div key={`${b.repo} ${b.branch}`} className="space-y-1">
           <div className="flex items-center justify-between gap-2">
-            <span
-              className="flex-1 truncate font-mono text-xs text-zinc-300"
-              title={b.branch}
-            >
-              {b.branch}
+            <span className="flex min-w-0 flex-1 items-baseline gap-1.5" title={`${b.repo} · ${b.branch}`}>
+              <span className="shrink-0 truncate text-xs text-zinc-500">{b.repo}</span>
+              <span className="shrink-0 text-zinc-700">/</span>
+              <span className="truncate font-mono text-xs text-zinc-300">{b.branch}</span>
             </span>
             <div className="flex shrink-0 items-center gap-3 text-xs tabular-nums">
               <span className="text-zinc-400">{compact(b.effectiveTokens)}</span>

--- a/src/components/design-system/organisms/ConfigProfile/ConfigProfile.tsx
+++ b/src/components/design-system/organisms/ConfigProfile/ConfigProfile.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/design-system/atoms/Badge/Badge';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { ConfigProfileProps } from './types';
 import { formatPlan } from './utils';
 
@@ -13,7 +14,10 @@ export function ConfigProfile({ config }: ConfigProfileProps) {
   return (
     <div className="card p-5 flex flex-col">
       <div className="mb-4 flex-none">
-        <h3 className="text-sm font-bold uppercase tracking-wider text-zinc-300">Claude Code Config Profile</h3>
+        <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
+          Claude Code Config Profile
+          <InfoTip text="Your active Claude Code CLI settings read from settings.json: default model, effort level, subscription, permission mode, enabled integrations, and the workspaces & command prefixes you've authorized." />
+        </h3>
         <p className="text-xs text-zinc-500 mt-0.5">Current active CLI environment settings</p>
       </div>
 

--- a/src/components/design-system/organisms/CostCalculation/CostCalculation.tsx
+++ b/src/components/design-system/organisms/CostCalculation/CostCalculation.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { usd, compact } from '@/lib/format';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { ModelPrice } from './types';
 import { PRICING_DATA } from './utils';
 
@@ -28,7 +29,10 @@ export function CostCalculation() {
     <div className="card p-6">
       <div className="mb-6 flex flex-col justify-between gap-4 md:flex-row md:items-center">
         <div>
-          <h2 className="text-lg font-bold text-zinc-100">Cost Calculation Explained</h2>
+          <h2 className="flex items-center gap-2 text-lg font-bold text-zinc-100">
+            Cost Calculation Explained
+            <InfoTip text="Reference pay-as-you-go API prices (per 1M tokens, by model). Your subscription has no per-token bill — these power the 'estimated equivalent cost' figures. Use the calculator to price a hypothetical request; cache reads are billed at ~10% of input." />
+          </h2>
           <p className="text-xs text-zinc-500">
             Anthropic charges based on the number of tokens processed. Cache reads are discounted by 90%.
           </p>

--- a/src/components/design-system/organisms/McpBreakdown/McpBreakdown.tsx
+++ b/src/components/design-system/organisms/McpBreakdown/McpBreakdown.tsx
@@ -50,25 +50,34 @@ export function McpBreakdown({ data }: McpBreakdownProps) {
         </div>
       </div>
 
-      {/* Per-server list */}
+      {/* Plain-language explanation of what the split means */}
+      <p className="text-[11px] leading-relaxed text-zinc-500">
+        <span className="text-zinc-400">Built-in</span> = Claude's native tools (Read, Bash, Edit…).{' '}
+        <span className="text-zinc-400">MCP</span> = tools from connected MCP servers. Numbers are
+        tool-call counts in this window; <span className="text-red-400">errors</span> are calls that
+        failed or were rejected.
+      </p>
+
+      {/* Per-server table: name · calls · errors, columns aligned */}
       {data.perServer.length > 0 && (
         <div>
-          <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
-            Per server
+          <div className="mb-1.5 flex items-center gap-2 border-b border-white/5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+            <span className="flex-1">MCP server</span>
+            <span className="w-14 text-right">calls</span>
+            <span className="w-14 text-right">errors</span>
           </div>
           <div className="space-y-1.5">
             {data.perServer.map((s) => (
-              <div key={s.server} className="flex items-center justify-between gap-2 text-xs">
-                <span
-                  className="flex-1 truncate font-mono text-zinc-400"
-                  title={s.server}
-                >
+              <div key={s.server} className="flex items-center gap-2 text-xs">
+                <span className="flex-1 truncate font-mono text-zinc-400" title={s.server}>
                   {s.server}
                 </span>
-                <span className="tabular-nums text-zinc-300">{compact(s.calls)}</span>
-                {s.errors > 0 && (
-                  <span className="tabular-nums text-red-400">{s.errors} err</span>
-                )}
+                <span className="w-14 text-right tabular-nums text-zinc-300">{compact(s.calls)}</span>
+                <span
+                  className={`w-14 text-right tabular-nums ${s.errors > 0 ? 'text-red-400' : 'text-zinc-600'}`}
+                >
+                  {s.errors > 0 ? s.errors : '—'}
+                </span>
               </div>
             ))}
           </div>

--- a/src/components/design-system/organisms/ProjectBreakdown/ProjectBreakdown.tsx
+++ b/src/components/design-system/organisms/ProjectBreakdown/ProjectBreakdown.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { compact, usd } from '@/lib/format';
 import { ToggleGroup } from '@/components/design-system/atoms/ToggleGroup/ToggleGroup';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { ProjectBreakdownProps, LocalProjectStat } from './types';
 import { normalizePath } from './utils';
 
@@ -92,8 +93,9 @@ export function ProjectBreakdown({
     return (
       <div className="card p-5 h-full flex flex-col justify-between min-h-[260px]">
         <div>
-          <h3 className="text-sm font-bold uppercase tracking-wider text-zinc-300">
+          <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
             Workspace Analytics · {periodDays}d
+            <InfoTip text="Per-project rollup of your sessions — cost, time, effective tokens and files touched, one row per project. Sort with the buttons. Cowork sessions run in a sandbox with no host project, so they're excluded here." />
           </h3>
           <p className="text-xs text-zinc-500 mt-0.5">Summary of activity across development projects</p>
         </div>
@@ -108,8 +110,9 @@ export function ProjectBreakdown({
     <div className="card p-5 flex flex-col h-full">
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between flex-none">
         <div>
-          <h3 className="text-sm font-bold uppercase tracking-wider text-zinc-300">
+          <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
             Workspace Analytics · {periodDays}d
+            <InfoTip text="Per-project rollup of your sessions — cost, time, effective tokens and files touched, one row per project. Sort with the buttons. Cowork sessions run in a sandbox with no host project, so they're excluded here." />
           </h3>
           <p className="text-xs text-zinc-500 mt-0.5">Summary of activity across development projects</p>
         </div>

--- a/src/components/design-system/organisms/SessionHistoryTable/SessionHistoryTable.tsx
+++ b/src/components/design-system/organisms/SessionHistoryTable/SessionHistoryTable.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { compact } from '@/lib/format';
 import { ExportButton } from '@/components/design-system/molecules/ExportButton/ExportButton';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { Modal } from '@/components/design-system/molecules/Modal/Modal';
 import { useTranscript } from '@/hooks/useTranscript';
 import { useSearch } from '@/hooks/useSearch';
@@ -215,8 +216,9 @@ export function SessionHistoryTable({
     <div className="card p-5 flex flex-col h-full">
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between flex-none">
         <div>
-          <h3 className="text-sm font-bold uppercase tracking-wider text-zinc-300">
+          <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
             Session History Log · {periodDays}d
+            <InfoTip text="Every session in the window — start time, project, first prompt, duration and tokens. Click a row to open its full transcript. Search by project name or prompt text; export the list with the button." />
           </h3>
           <p className="text-xs text-zinc-500 mt-0.5">Search and review past execution records</p>
         </div>
@@ -273,7 +275,7 @@ export function SessionHistoryTable({
           <tbody className="divide-y divide-white/5 text-zinc-300">
             {paginatedSessions.length > 0 ? (
               paginatedSessions.map((s) => {
-                const projectName = getProjectName(s.project_path);
+                const projectName = s.source === 'cowork' ? 'Cowork' : getProjectName(s.project_path);
                 const totalToks = s.effective_tokens ?? (s.input_tokens ?? 0) + (s.output_tokens ?? 0);
 
                 return (
@@ -346,7 +348,7 @@ export function SessionHistoryTable({
           modalSession && (
             <div className="flex items-center gap-3 min-w-0 text-sm">
               <span className="font-bold text-zinc-100 truncate">
-                {getProjectName(modalSession.project_path)}
+                {modalSession.source === 'cowork' ? 'Cowork' : getProjectName(modalSession.project_path)}
               </span>
               <span className="text-zinc-500 font-mono text-xs flex-none">
                 {formatDate(modalSession.start_time)}

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -9,24 +9,48 @@ interface State<T> {
   loading: boolean;
 }
 
+interface Cached {
+  data: unknown;
+  computedAt: number | null;
+  claudeDir: string | null;
+}
+
+// Module-level stale-while-revalidate cache, keyed by URL. Lets the UI re-show a
+// previously fetched response instantly when the user switches back to it (e.g.
+// flipping the source filter Code↔Cowork), instead of clearing to a skeleton and
+// waiting on a fresh round-trip every time. The background fetch still runs to
+// refresh the data. Keys are a finite set of API URLs, so the map stays small.
+const cache = new Map<string, Cached>();
+
 export function usePolling<T>(url: string, intervalMs = 5000): State<T> & { lastFetch: number } {
-  const [state, setState] = useState<State<T>>({
-    data: null,
-    computedAt: null,
-    claudeDir: null,
-    error: null,
-    loading: true,
+  const [state, setState] = useState<State<T>>(() => {
+    const hit = cache.get(url);
+    return hit
+      ? { data: hit.data as T, computedAt: hit.computedAt, claudeDir: hit.claudeDir, error: null, loading: false }
+      : { data: null, computedAt: null, claudeDir: null, error: null, loading: true };
   });
   const [lastFetch, setLastFetch] = useState(0);
   const alive = useRef(true);
 
   useEffect(() => {
     alive.current = true;
+    // On URL change (source/range filter switch): if we already have a cached
+    // response for this exact URL, show it immediately (no skeleton) and revalidate
+    // in the background. Otherwise clear to a skeleton until the first response lands.
+    // Interval re-ticks reuse the same URL, so this never flashes on a normal poll.
+    const hit = cache.get(url);
+    if (hit) {
+      setState({ data: hit.data as T, computedAt: hit.computedAt, claudeDir: hit.claudeDir, error: null, loading: false });
+    } else {
+      setState({ data: null, computedAt: null, claudeDir: null, error: null, loading: true });
+    }
+
     async function tick() {
       try {
         const res = await fetch(url);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const env: Envelope<T> = await res.json();
+        cache.set(url, { data: env.data, computedAt: env.computedAt, claudeDir: env.claudeDir });
         if (!alive.current) return;
         setState({
           data: env.data,
@@ -38,6 +62,7 @@ export function usePolling<T>(url: string, intervalMs = 5000): State<T> & { last
         setLastFetch(Date.now());
       } catch (e) {
         if (!alive.current) return;
+        // Keep any cached/last data on screen; just surface the error.
         setState((s) => ({ ...s, error: String(e), loading: false }));
         setLastFetch(Date.now());
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,20 @@ export interface TokenTotals {
   cost: number;
 }
 
+export type UsageSource = 'code' | 'cowork';
+
+/** Effective-token totals split by surface (Code vs Cowork). */
+export interface SourceSplit {
+  code: TokenTotals;
+  cowork: TokenTotals;
+}
+
+/** /api/sources — which usage surfaces have local data. Gates all Cowork UI. */
+export interface SourcesInfo {
+  code: { events: number; lastTs: number };
+  cowork: { available: boolean; events: number; lastTs: number };
+}
+
 export interface VersionInfo {
   current: string;
   latest: string | null;
@@ -42,6 +56,7 @@ export interface RecentData {
   buckets: Bucket[];
   totals: TokenTotals;
   byModel: ModelShare[];
+  bySource?: SourceSplit;
   activeBlock: ActiveBlock;
 }
 
@@ -53,6 +68,7 @@ export interface WeeklyData {
   totals: TokenTotals;
   prevTotals: TokenTotals;
   byModel: ModelShare[];
+  bySource?: SourceSplit;
   cacheEfficiency?: { date: string; hitRate: number; cacheReadTokens: number; totalTokens: number }[];
 }
 
@@ -116,6 +132,7 @@ export interface ClaudeConfig {
 
 export interface SessionMeta {
   session_id: string;
+  source?: UsageSource;
   project_path: string;
   start_time: string;
   duration_minutes: number;
@@ -205,6 +222,7 @@ export interface InsightsLanguages {
 
 export interface InsightsBranches {
   branch: string;
+  repo: string;
   effectiveTokens: number;
   cost: number;
   sessions: number;


### PR DESCRIPTION
## What

Adds **Claude Cowork** (desktop "local agent mode") usage to the dashboard alongside Claude Code, behind a dynamic source filter, plus explainer **"?" tooltips on every card** and a few perf/UX fixes.

**Claude Chat is intentionally out of scope** — its conversations live in an opaque IndexedDB leveldb with no usable per-message token data; only the existing `/api/usage/live` OAuth endpoint reflects it (account-level).

## Why

Cowork writes standard Claude Code JSONL transcripts under the desktop app's `local-agent-mode-sessions` root — the same format the dashboard already parses — so its usage was on disk but unreported. ~113MB / 2,700+ events verified locally.

## Backend
- Shared `scanRoots()` (code + cowork) walked by both `scan.ts` and `insights-scan.ts`; every `UsageEvent` / session tagged `source: 'code' | 'cowork'`. Dedup map is shared across roots.
- `GET /api/sources` reports `cowork.available`; usage/sessions/insights routes accept `?source=all|code|cowork` (`filterSource` / `scopeInsights`).
- `buildProjectStats` excludes cowork (sandbox paths); `buildBranches` now groups by **repo + branch** and returns the repo name.
- Event + insights caches warmed on startup so the first request skips the ~7s cold scan.

## Frontend
- Header **source toggle** + **Sources split card**, rendered only when Cowork data exists → Code-only users get the original dashboard byte-for-byte.
- Sessions tab is **table-only under Cowork** (no host project to group by; cowork rows labeled "Cowork").
- `usePolling` gains a **stale-while-revalidate cache** (instant return to an already-loaded source) and loading **skeletons no longer collapse to 0 height**.
- New **`InfoTip`** atom — a "?" hover explainer wired into `Section`/`StatCard` and every organism card across **all 6 tabs** (~32 cards).
- **MCP card redesigned**: aligned `server · calls · errors` columns + plain-language explanation.

## Infra / docs
- `docker-compose.yml`: second read-only mount for the Cowork root (`COWORK_DIR`), with a safe fallback so zero-config still boots.
- `.env.example` + `CLAUDE.md` updated (new `source` dimension, `COWORK_DIR`, caveats: full-VM-sandbox Cowork not captured, Chat unavailable locally).

## Verification
- `npx tsc -b` clean (the project's only correctness bar).
- Drove the app in a browser across **every tab × All/Code/Cowork**: per-source totals reconcile (code + cowork = all), projects exclude cowork, sessions/insights scope correctly, no console errors.
- Per-source session counts: cowork 44 / code 80 / all 124; warm fetches ~50–130ms.

## Notes
- Caveat preserved: full-VM-sandbox Cowork runs keep transcripts inside the VM → not captured (host-side local-agent sessions only).
- This app runs in Docker; reviewers testing locally need `COWORK_DIR_HOST` set in `.env` and `npm run docker:up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)