### PR TITLE
docs: add CHANGELOG and point update banner at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.4] - 2026-06-12
+
+### Added
+- This changelog, with retroactive entries for every prior release.
+
+### Changed
+- The in-app "update available" banner's **View changelog** link now points at
+  this file instead of the raw commit log.
+
+## [0.1.3] - 2026-06-12
+
+### Added
+- **Claude Cowork usage tracking** — JSONL written by the Cowork desktop app's
+  "local agent mode" is now ingested alongside the `~/.claude` logs.
+- Header **source filter** (Code / Cowork / All), shown only when Cowork data is
+  present, so Code-only users see the original dashboard unchanged.
+- Per-card help tips explaining what each metric means.
+
+### Changed
+- Scan and aggregation performance improvements.
+
+## [0.1.2] - 2026-06-11
+
+### Fixed
+- Update-banner commands are now emitted one per line instead of being joined
+  with `&&`, which is a parse error in Windows PowerShell 5.1.
+
+## [0.1.1] - 2026-06-11
+
+### Added
+- **Insights tab** with an analytics API and live subagent detection.
+- Dedicated **Agents tab** with live main-session agents, a delegating state, and
+  plan usage shown above the agents.
+- **Live session history** with a per-session modal, transcripts (LTR), and search.
+- In-app **"update available" banner** and an auto version-bump CI workflow.
+- Richer config profile and content-height cards with scrollable lists.
+
+### Changed
+- Refactored the UI into an atomic design system.
+- Idle main sessions now dim after 30s and drop after 60s; completed subagents no
+  longer keep an idle parent card alive.
+
+### Fixed
+- Accurate token dedup and local-timezone day buckets.
+- Heatmap tooltips anchored correctly at edge columns.
+
+## [0.1.0] - 2026-06-10
+
+### Added
+- Initial local, offline Claude Code usage dashboard that reads the `~/.claude`
+  logs: current 5-hour block, weekly trends, model breakdown, tool usage, and an
+  activity heatmap.
+- **Docker setup** — a single Express process serves the API and built UI on
+  `:8787` with `~/.claude` mounted read-only.
+- 4-tab layout, API-cost estimation with user-set spend limits, a daily
+  Tokens/Cost toggle with projections, skeleton loading states, and a
+  macOS/Linux offline-commands banner.
+
+### Fixed
+- Windows path resolution.
+- Live-API fallback to the local logs when there is no active block
+  (`resets_at = null`).
+
+[0.1.4]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.4
+[0.1.3]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.3
+[0.1.2]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.2
+[0.1.1]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.1
+[0.1.0]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/version.ts
+++ b/server/version.ts
@@ -14,7 +14,7 @@ export interface VersionInfo {
   updateAvailable: boolean;
   isDocker: boolean;
   repoUrl: string;
-  compareUrl: string;
+  changelogUrl: string;
 }
 
 interface LocalPackage {
@@ -107,7 +107,7 @@ export async function getVersionInfo(): Promise<VersionInfo> {
     updateAvailable,
     isDocker: isDocker(),
     repoUrl: local.repoUrl,
-    // GitHub renders this commit log even without a `v` tag (avoids a 404).
-    compareUrl: `${local.repoUrl}/commits/main`,
+    // Link the update banner straight to the changelog on GitHub.
+    changelogUrl: `${local.repoUrl}/blob/main/CHANGELOG.md`,
   };
 }

--- a/src/components/design-system/molecules/UpdateBanner/UpdateBanner.tsx
+++ b/src/components/design-system/molecules/UpdateBanner/UpdateBanner.tsx
@@ -72,12 +72,12 @@ export function UpdateBanner({ data }: UpdateBannerProps) {
         <p className="font-semibold text-amber-300">
           Update available — v{data.current} → v{data.latest}{' '}
           <a
-            href={data.compareUrl}
+            href={data.changelogUrl}
             target="_blank"
             rel="noreferrer"
             className="font-normal text-amber-400/80 hover:text-amber-200 underline underline-offset-2"
           >
-            View changes ↗
+            View changelog ↗
           </a>
         </p>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface VersionInfo {
   updateAvailable: boolean;
   isDocker: boolean;
   repoUrl: string;
-  compareUrl: string;
+  changelogUrl: string;
 }
 
 export interface Bucket extends TokenTotals {


### PR DESCRIPTION
## What

The update banner's **View changes ↗** link pointed at the raw commit log (`/commits/main`). This adds a real, human-readable **`CHANGELOG.md`** (Keep a Changelog format), backfilled retroactively for every release, and repoints the banner at it.

## Changes
- **`CHANGELOG.md`** (new) — retroactive entries for v0.1.0 → v0.1.4.
- **`server/version.ts`** — rename `VersionInfo.compareUrl` → `changelogUrl`; value now `${repoUrl}/blob/main/CHANGELOG.md`.
- **`src/types.ts`** — mirror the rename.
- **`UpdateBanner.tsx`** — use `data.changelogUrl`; link text "View changes ↗" → "View changelog ↗".
- **`package.json`** — bump to `0.1.4` (the auto version-bump CI no-ops since HEAD already differs from main).

## Verify
- `npx tsc -b` clean.
- `GET /api/version` returns `changelogUrl: https://github.com/iftahs/claude-dashboard/blob/main/CHANGELOG.md`.
- The blob link renders once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)