### PR TITLE
chore: bump version to v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-06-14
+
+### Added
+- API / pay-as-you-go usage mode: auto-detected from your Claude credentials, with a
+  cost view (estimated spend per block, spend-vs-caps) replacing the subscription
+  rate-limit framing for users without a Claude.ai subscription token.
+- Settings modal (⚙) with a manual usage-mode override and spending-cap configuration.
+
+### Changed
+- The "session expired" banner now only shows for subscription users; API users see a
+  neutral "API · pay-as-you-go" note instead.
+
 ## [0.1.6] - 2026-06-12
 
 ### Added
@@ -83,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.7]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.7
 [0.1.6]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.6
 [0.1.5]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.5
 [0.1.4]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",


### PR DESCRIPTION
Bumps the version to **v0.1.7** following the API / pay-as-you-go usage mode feature merged in #11 (the bump wasn't included in that merge).

### Changes
- `package.json` + `package-lock.json` → `0.1.7`
- `CHANGELOG.md` → new `## [0.1.7] - 2026-06-14` section covering API mode, the Settings modal, and the banner change, plus the release-link reference (matching the v0.1.6 format).

> Note: the repo's CI auto-generates changelog entries per PR. This manual entry follows the established v0.1.6 convention — dedupe with the CI entry if it appends one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)