### PR TITLE
feat: live counters on Live Usage and Agents tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,13 @@ const SOURCE_OPTIONS: { value: SourceFilter; label: string }[] = [
 ];
 const SOURCE_COLOR: Record<UsageSource, string> = { code: '#d97757', cowork: '#6366f1' };
 
+// Pill color for the Live Usage tab badge, scaled by 5-hour limit utilization.
+function usagePillClasses(pct: number): string {
+  if (pct >= 80) return 'bg-red-500/15 text-red-300';
+  if (pct >= 50) return 'bg-amber-500/15 text-amber-300';
+  return 'bg-emerald-500/15 text-emerald-300';
+}
+
 export default function App() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -137,6 +144,18 @@ export default function App() {
     (weekly.data?.totals.totalTokens ?? 0) === 0;
 
   const block = recent.data?.activeBlock ?? null;
+  // Live count of agents working in parallel right now: running subagents +
+  // main sessions that are actively working or delegating. Drives the Agents
+  // tab badge (visible from any tab) and the Agents section header chips.
+  const runningAgentCount =
+    (liveSubagents.data?.running.length ?? 0) +
+    (liveSubagents.data?.mainAgents.filter((m) => m.active || m.delegating).length ?? 0);
+  // Current 5-hour limit utilization (already 0–100) for the Live Usage tab badge.
+  // Only when the live API returned a value for an active block (no error).
+  const fiveHourPct =
+    liveUsage.data && !liveUsage.data.error && liveUsage.data.five_hour?.resets_at != null
+      ? Math.round(liveUsage.data.five_hour.utilization)
+      : null;
   const topModel = models.data?.models[0];
   const weeklyEffective = weekly.data?.totals.effectiveTokens ?? 0;
   const prevWeeklyEffective = weekly.data?.prevTotals.effectiveTokens ?? 0;
@@ -213,7 +232,26 @@ export default function App() {
                 : 'text-zinc-500 hover:text-zinc-300 hover:bg-ink-700/40'
             }`}
           >
-            {label}
+            <span className="inline-flex items-center gap-1.5">
+              {label}
+              {id === 'agents' && runningAgentCount > 0 && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-clay-500/20 px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-clay-300"
+                  title={`${runningAgentCount} agent${runningAgentCount === 1 ? '' : 's'} running right now`}
+                >
+                  <span className="pulse-dot flex-none" />
+                  {runningAgentCount}
+                </span>
+              )}
+              {id === 'live' && fiveHourPct != null && (
+                <span
+                  className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums ${usagePillClasses(fiveHourPct)}`}
+                  title={`5-hour limit: ${fiveHourPct}% used`}
+                >
+                  {fiveHourPct}%
+                </span>
+              )}
+            </span>
           </button>
         ))}
       </div>

--- a/src/components/design-system/organisms/AgentActivity/AgentActivity.tsx
+++ b/src/components/design-system/organisms/AgentActivity/AgentActivity.tsx
@@ -230,6 +230,17 @@ function GroupLabel({ children }: { children: string }) {
   );
 }
 
+// Live tally shown in the section header: how many agents/subagents are running
+// in parallel right now. Pulses while anything is active.
+function CountChip({ count, label, pulse }: { count: number; label: string; pulse?: boolean }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/5 px-2.5 py-1 text-xs font-semibold tabular-nums text-zinc-300 ring-1 ring-white/10">
+      {pulse && <span className="pulse-dot flex-none" />}
+      {count} {label}
+    </span>
+  );
+}
+
 export function AgentActivity({ data, loading }: AgentActivityProps) {
   const running = data?.running ?? [];
   const completed = data?.recentlyCompleted ?? [];
@@ -242,10 +253,29 @@ export function AgentActivity({ data, loading }: AgentActivityProps) {
   const orphanRunning = running.filter((r) => !mainKeys.has(r.parentKey));
   const orphanCompleted = completed.filter((c) => !mainKeys.has(c.parentKey));
 
+  const runningSubagents = running.length;
+  const activeMains = mains.filter((m) => m.active || m.delegating).length;
+
   return (
     <Section
       title="Agents · live activity"
       help="Live view of agents working right now: main agents, their running subagents (Task/Agent spawns), and recently finished ones — refreshed every few seconds from active session logs. Empty when nothing is running."
+      right={
+        runningSubagents > 0 || activeMains > 0 ? (
+          <div className="flex items-center gap-2">
+            {runningSubagents > 0 && (
+              <CountChip
+                count={runningSubagents}
+                label={runningSubagents === 1 ? 'subagent' : 'subagents'}
+                pulse
+              />
+            )}
+            {activeMains > 0 && (
+              <CountChip count={activeMains} label={activeMains === 1 ? 'main' : 'mains'} />
+            )}
+          </div>
+        ) : undefined
+      }
     >
       {loading && !data ? (
         <div className="h-10 flex items-center text-xs text-zinc-600">Loading…</div>


### PR DESCRIPTION
## What

Two always-visible live badges on the tab bar:

- **Agents tab** — pulsing badge with the count of agents running in parallel right now (running subagents + active/delegating main sessions). Matching count chips added to the Agents section header (`N subagents` pulsing + `N mains`).
- **Live Usage tab** — severity-colored badge with current **5-hour limit** utilization (green <50%, amber 50–79%, red ≥80%). Shows only when the live API returns an active block.

## How

- Counts derived in `App.tsx` from already-polled `/api/subagents/live` (4s) and `/api/usage/live` (15s).
- No backend changes; no new endpoints.
- `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)