### PR TITLE
fix: AI Insights review follow-ups (credential leak, path scrub, Node engines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2026-06-21
+
+### Fixed
+- Clear saved API key when switching AI providers to prevent credential leaks.
+- Scrub sensitive path/sessionId keys from model prompts to honor AI privacy.
+- Align Node engine requirement with dependencies to ensure compatibility.
+
 ## [0.1.8] - 2026-06-21
 
 ### Added
@@ -108,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.9]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.9
 [0.1.8]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.8
 [0.1.7]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.7
 [0.1.6]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.6

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A full-screen settings view (pinned to the bottom of the sidebar) for **usage mo
 
 ## Quick start
 
-Requires [Node.js](https://nodejs.org) 18+.
+Requires [Node.js](https://nodejs.org) 20+ (the active LTS — some dependencies require it).
 
 ```bash
 git clone https://github.com/iftahs/claude-dashboard.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",
   "author": "Iftah Saar (https://iftah.dev)",
+  "engines": {
+    "node": ">=20"
+  },
   "homepage": "https://github.com/iftahs/claude-dashboard",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/ai-context.ts
+++ b/server/ai-context.ts
@@ -129,9 +129,32 @@ const SECTION_PROMPTS: Record<string, string> = {
   plugins: 'Summarize this plugins & MCP inventory: installed plugins, MCP servers and any notable integrations.',
 };
 
+// Keys that may carry full paths or session identifiers. The privacy contract is
+// that those never leave the machine, so strip them from any panel payload before
+// it goes into a prompt bound for an external model (e.g. FileChurn's `path`,
+// Complexity's `sessionId`). Aggregate metrics and basenames are kept.
+const SENSITIVE_KEYS = new Set(
+  ['path', 'filePath', 'fullPath', 'projectPath', 'project_path', 'cwd', 'sessionId', 'transcriptPath'].map((k) =>
+    k.toLowerCase(),
+  ),
+);
+
+function scrubForModel(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(scrubForModel);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.has(k.toLowerCase())) continue;
+      out[k] = scrubForModel(v);
+    }
+    return out;
+  }
+  return value;
+}
+
 export function buildSectionUserMessage(section: string, data: unknown): string {
   const instr = SECTION_PROMPTS[section] ?? 'Summarize this dashboard panel data in 2-3 plain-language sentences.';
-  return `${instr}\n\nDATA (JSON):\n${JSON.stringify(data)}`;
+  return `${instr}\n\nDATA (JSON):\n${JSON.stringify(scrubForModel(data))}`;
 }
 
 // ── Follow-up suggestions ───────────────────────────────────────────────────

--- a/src/components/design-system/organisms/SettingsView/SettingsView.tsx
+++ b/src/components/design-system/organisms/SettingsView/SettingsView.tsx
@@ -27,8 +27,11 @@ export function SettingsView({
   const providers = Object.keys(PROVIDER_LABELS) as AiProvider[];
 
   function changeProvider(provider: AiProvider) {
-    // Reset model to the new provider's first option.
-    onChangeAiConfig({ ...aiConfig, provider, model: PROVIDER_MODELS[provider][0] });
+    // Reset the model to the new provider's first option AND clear the saved key:
+    // keys are provider-specific, so carrying one over would send the wrong
+    // credential to the new provider's API (e.g. an Anthropic key to OpenAI).
+    setAiKey('');
+    onChangeAiConfig({ ...aiConfig, provider, model: PROVIDER_MODELS[provider][0], apiKey: '' });
   }
   function saveAiKey() {
     onChangeAiConfig({ ...aiConfig, apiKey: aiKey.trim() });


### PR DESCRIPTION
Follow-up to #15 — these three Codex review fixes landed on the branch **after** #15 was merged, so they're not in `main` yet.

### Fixes
- **P1 — provider key leak** (`SettingsView.tsx`): switching the AI provider kept the saved `apiKey`, so a key for one provider could be sent to another's API (e.g. an Anthropic key to OpenAI). `changeProvider` now clears the key (and the input) on switch.
- **P2 — scrub panel data** (`server/ai-context.ts`): `buildSectionUserMessage` now strips path/sessionId-style keys (`path`, `filePath`, `projectPath`, `sessionId`, `cwd`, …) from the panel payload before it goes into a model prompt — covers FileChurn's `path` and Complexity's `sessionId`, honoring the AI privacy contract. Done at the server egress point so it applies to every caller.
- **P2 — Node engines**: `react-router-dom@7` / `cross-env@10` require Node ≥20, but the docs said 18+. Added `engines.node >=20` and bumped the README.

### Verification
- `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)