### PR TITLE
Support running through a LiteLLM proxy (AI Insights + actual billed cost) + contrast pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,24 @@ CLAUDE_DIR_HOST=C:/Users/you/.claude
 #     Get one at https://console.anthropic.com/settings/keys
 #ANTHROPIC_API_KEY=sk-ant-...
 #
-# Optional model override for the server-side fallback (default claude-opus-4-8):
+# (c) Or route through a corporate LLM proxy (LiteLLM / gateway) using Claude
+#     Code's own env vars. The token is sent as an Authorization: Bearer header;
+#     the base URL must expose the Anthropic Messages format (/v1/messages):
+#ANTHROPIC_BASE_URL=https://litellm.company.com
+#ANTHROPIC_AUTH_TOKEN=sk-litellm-...
+#
+# Optional model override for the server-side fallback (default claude-opus-4-8).
+# Set this if your proxy doesn't serve claude-opus-4-8 (else calls 400/404):
 #AI_MODEL=claude-sonnet-4-6
+
+# OPTIONAL — "Actual billed" cost from a LiteLLM gateway.
+# When you run Claude Code through a LiteLLM proxy, the dashboard shows the REAL
+# cost billed by the gateway next to the estimate. By default it reuses your
+# ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (the virtual key is self-scoped, so it
+# can read its own /user/daily/activity — no master key needed). Override only if
+# the gateway/key for reading spend differs (e.g. a key with spend-view permission):
+#LITELLM_BASE_URL=https://litellm.company.com
+#LITELLM_API_KEY=sk-litellm-...
 
 # OPTIONAL — Anonymous product analytics (PostHog). The dashboard sends only
 # anonymous feature-usage events (which tab is opened, exports, an anonymous

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,19 @@ services:
       # CLI, so set ANTHROPIC_API_KEY in .env for a dedicated, un-throttled
       # backend. Unset → falls back to the Claude.ai OAuth token (works, but is
       # rate-limited → may 429). AI_MODEL is optional (default claude-opus-4-8).
+      # To route through a corporate LLM proxy (LiteLLM / gateway) instead, set
+      # ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN in .env (the token is sent as a
+      # bearer Authorization header). Host shell vars are NOT auto-passed, so they
+      # must be listed here. Set AI_MODEL if the proxy doesn't serve claude-opus-4-8.
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
+      - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:-}
       - AI_MODEL=${AI_MODEL:-}
+      # OPTIONAL — when on a LiteLLM proxy, the dashboard shows the gateway's ACTUAL
+      # billed cost beside the estimate. By default it reuses ANTHROPIC_BASE_URL +
+      # ANTHROPIC_AUTH_TOKEN; set these only if the spend-read key/url differs.
+      - LITELLM_BASE_URL=${LITELLM_BASE_URL:-}
+      - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       # Day buckets follow the container clock — pin it to your local timezone
       # (override TZ in .env if you are not in Asia/Jerusalem).
       - TZ=${TZ:-Asia/Jerusalem}

--- a/server/ai.ts
+++ b/server/ai.ts
@@ -46,6 +46,26 @@ const MAX_OUTPUT_TOKENS = 1024;
 const CLI_PROBE_TTL = 5 * 60_000;
 const ANTHROPIC_VERSION = '2023-06-01';
 
+// Honor Claude Code's own proxy/gateway env vars so AI Insights works against a
+// corporate LiteLLM/gateway. ANTHROPIC_BASE_URL = proxy origin; ANTHROPIC_AUTH_TOKEN
+// = its bearer token (sent as Authorization, matching Claude Code). Falls back to
+// api.anthropic.com + x-api-key (ANTHROPIC_API_KEY) when unset.
+function anthropicBaseUrl(): string {
+  const raw = (process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').trim();
+  return raw.replace(/\/+$/, '').replace(/\/v1$/, ''); // tolerate trailing slash and/or /v1
+}
+function messagesUrl(): string {
+  return `${anthropicBaseUrl()}/v1/messages`;
+}
+/** Server-env credential for the Messages backend; proxy auth token wins over api key. */
+function envApiHeaders(): Record<string, string> | null {
+  const token = (process.env.ANTHROPIC_AUTH_TOKEN || '').trim();
+  if (token) return { authorization: `Bearer ${token}` };
+  const key = (process.env.ANTHROPIC_API_KEY || '').trim();
+  if (key) return { 'x-api-key': key };
+  return null;
+}
+
 let cliProbe: { ok: boolean; at: number } | null = null;
 
 // On Windows the `claude` command is a .cmd/.ps1 shim, which execFile cannot
@@ -75,7 +95,7 @@ export async function claudeCliAvailable(): Promise<boolean> {
 
 /** Decide which backend will serve a call right now. */
 export async function resolveBackend(): Promise<AiStatus> {
-  if (process.env.ANTHROPIC_API_KEY) return { available: 'apikey', model: DEFAULT_MODEL };
+  if (envApiHeaders()) return { available: 'apikey', model: DEFAULT_MODEL };
   if (await claudeCliAvailable()) return { available: 'cli', model: DEFAULT_MODEL };
   const creds = await readCredentials();
   const token = creds?.claudeAiOauth?.accessToken;
@@ -83,7 +103,7 @@ export async function resolveBackend(): Promise<AiStatus> {
   if (token && !(expiresAt && Date.now() >= expiresAt)) return { available: 'api', model: DEFAULT_MODEL };
   if (token && expiresAt && Date.now() >= expiresAt)
     return { available: 'none', model: DEFAULT_MODEL, reason: 'OAuth token expired — run any Claude Code command to refresh it.' };
-  return { available: 'none', model: DEFAULT_MODEL, reason: 'No Claude CLI and no Claude.ai token found. Install Claude Code or set ANTHROPIC_API_KEY.' };
+  return { available: 'none', model: DEFAULT_MODEL, reason: 'No Claude CLI and no Claude.ai token found. Install Claude Code, or set ANTHROPIC_AUTH_TOKEN (+ ANTHROPIC_BASE_URL for a proxy) or ANTHROPIC_API_KEY.' };
 }
 
 export async function runAi(
@@ -134,7 +154,7 @@ function runViaCli(input: AiCallInput, model: string): Promise<string> {
 // ── Anthropic Messages API (shared) ───────────────────────────────────────────
 
 async function callMessages(headers: Record<string, string>, input: AiCallInput, model: string): Promise<string> {
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
+  const res = await fetch(messagesUrl(), {
     method: 'POST',
     headers: { ...headers, 'content-type': 'application/json', 'anthropic-version': ANTHROPIC_VERSION },
     body: JSON.stringify({
@@ -147,7 +167,7 @@ async function callMessages(headers: Record<string, string>, input: AiCallInput,
   });
   if (res.status === 401 || res.status === 403)
     throw new AiTokenRejectedError(`Anthropic API rejected the credential (${res.status}).`);
-  if (!res.ok) throw new AiCallError(`Anthropic API error ${res.status} ${res.statusText}`);
+  if (!res.ok) throw new AiCallError(`Anthropic API error ${res.status} ${res.statusText} (model "${model}" via ${anthropicBaseUrl()})`);
   const data: any = await res.json();
   const text = Array.isArray(data?.content)
     ? data.content.filter((b: any) => b?.type === 'text').map((b: any) => b.text).join('').trim()
@@ -157,7 +177,7 @@ async function callMessages(headers: Record<string, string>, input: AiCallInput,
 }
 
 function runViaApiKey(input: AiCallInput, model: string): Promise<string> {
-  return callMessages({ 'x-api-key': process.env.ANTHROPIC_API_KEY as string }, input, model);
+  return callMessages(envApiHeaders()!, input, model);
 }
 
 // ── OpenAI ─────────────────────────────────────────────────────────────────
@@ -258,7 +278,7 @@ async function callMessagesStream(
   model: string,
   onDelta: (t: string) => void,
 ): Promise<void> {
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
+  const res = await fetch(messagesUrl(), {
     method: 'POST',
     headers: { ...headers, 'content-type': 'application/json', 'anthropic-version': ANTHROPIC_VERSION },
     body: JSON.stringify({
@@ -272,7 +292,7 @@ async function callMessagesStream(
   });
   if (res.status === 401 || res.status === 403)
     throw new AiTokenRejectedError(`Anthropic API rejected the credential (${res.status}).`);
-  if (!res.ok) throw new AiCallError(`Anthropic API error ${res.status} ${res.statusText}`);
+  if (!res.ok) throw new AiCallError(`Anthropic API error ${res.status} ${res.statusText} (model "${model}" via ${anthropicBaseUrl()})`);
   await pumpSSE(res, (j) => {
     if (j?.type === 'content_block_delta' && j.delta?.type === 'text_delta' && j.delta.text) onDelta(j.delta.text);
   });
@@ -390,7 +410,7 @@ export async function runAiStream(
   const model = input.model || status.model;
   if (status.available === 'apikey') {
     h.onStart('apikey');
-    await callMessagesStream({ 'x-api-key': process.env.ANTHROPIC_API_KEY as string }, input, model, h.onDelta);
+    await callMessagesStream(envApiHeaders()!, input, model, h.onDelta);
     return 'apikey';
   }
   if (status.available === 'cli') {

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import express from 'express';
 import { getEvents } from './cache.ts';
 import { buildRecent, buildWeekly, buildModels, buildActivity, buildTools, buildHourlyHeatmap, buildProjectStats, filterSource, type SourceFilter } from './aggregate.ts';
-import { claudeDir, readConfig, readCredentials, readStatsSummary, readSessionMetas, fetchLiveUsage, fetchLiveProfile } from './scan.ts';
+import { claudeDir, readConfig, readCredentials, readStatsSummary, readSessionMetas, fetchLiveUsage, fetchLiveProfile, detectLitellm, fetchLiteLlmSpend } from './scan.ts';
 import { getInsights } from './insights-scan.ts';
 import {
   buildErrors, buildRetries, buildLanguages, buildBranches, buildMcp,
@@ -101,7 +101,10 @@ app.get('/api/config', async (_req, res) => {
       // Offline or expired token — keep the values read from the local file.
     }
 
-    const merged = { ...config, subscriptionType, rateLimitTier, authMode };
+    // LiteLLM gateway detection (pure env read) — gates the "Actual billed" cost UI.
+    const litellm = detectLitellm();
+
+    const merged = { ...config, subscriptionType, rateLimitTier, authMode, litellm };
     res.json(wrap(merged, Date.now()));
   } catch (e) {
     res.status(500).json({ error: String(e) });
@@ -288,6 +291,19 @@ app.get('/api/usage/live', async (_req, res) => {
   try {
     const liveUsage = await fetchLiveUsage();
     res.json(wrap(liveUsage, Date.now()));
+  } catch (e: any) {
+    res.json(wrap({ error: e.message || String(e) }, Date.now()));
+  }
+});
+
+// Actual billed cost from a LiteLLM gateway (when configured): month-to-date,
+// previous-month same-period total, and a per-day breakdown over the selected
+// window (days clamp matches /api/usage/weekly). Like /api/usage/live, failures
+// return wrap({ error }) at HTTP 200 so the frontend just hides the cards.
+app.get('/api/usage/litellm', async (req, res) => {
+  try {
+    const days = Math.max(7, Math.min(28, Number(req.query.days ?? 7)));
+    res.json(wrap(await fetchLiteLlmSpend(days), Date.now()));
   } catch (e: any) {
     res.json(wrap({ error: e.message || String(e) }, Date.now()));
   }

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -456,12 +456,12 @@ export interface LiteLlmSpend {
   prevMonthToDate: number;   // previous month, 1st → same day-of-month (same-period comparison)
   lifetime: { user: number; key: number }; // lifetime spend (user across all keys / this key)
   // `days` calendar days incl. today, oldest→newest, zero-filled. Per-day cost,
-  // request count, and per-model spend (for the hover breakdown).
-  daily: { date: string; cost: number; requests: number; byModel: Record<string, number> }[];
+  // request count, successful count, and per-model spend (for the hover breakdown).
+  daily: { date: string; cost: number; requests: number; successful: number; byModel: Record<string, number> }[];
 }
 
 interface LiteLlmBase {
-  byDate: Map<string, { cost: number; requests: number; byModel: Record<string, number> }>;
+  byDate: Map<string, { cost: number; requests: number; successful: number; byModel: Record<string, number> }>;
   today: Date;
   monthLabel: string;
   monthToDate: number;
@@ -532,18 +532,24 @@ async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
   }
 
   // YYYY-MM-DD sorts lexicographically, so date-string range checks work directly.
-  const byDate = new Map<string, { cost: number; requests: number; byModel: Record<string, number> }>();
+  const byDate = new Map<string, { cost: number; requests: number; successful: number; byModel: Record<string, number> }>();
   let monthToDate = 0, monthRequests = 0, monthSuccessful = 0, monthFailed = 0, prevMonthToDate = 0;
   const monthTokens = { prompt: 0, completion: 0, cacheRead: 0, cacheCreate: 0 };
   for (const r of results) {
     const date = String(r?.date ?? '');
     if (!date) continue;
     const mx = r?.metrics ?? {};
-    const entry = byDate.get(date) ?? { cost: 0, requests: 0, byModel: {} };
+    const entry = byDate.get(date) ?? { cost: 0, requests: 0, successful: 0, byModel: {} };
     entry.cost += num(mx.spend);
     entry.requests += num(mx.api_requests);
+    entry.successful += num(mx.successful_requests);
+    // Per-model spend is nested under `.metrics.spend`; keys carry a provider prefix
+    // (e.g. "vertex_ai/claude-opus-4-8") which we strip and merge for display.
     const models = r?.breakdown?.models ?? {};
-    for (const [m, v] of Object.entries<any>(models)) entry.byModel[m] = (entry.byModel[m] ?? 0) + num(v?.spend);
+    for (const [m, v] of Object.entries<any>(models)) {
+      const name = m.includes('/') ? m.slice(m.lastIndexOf('/') + 1) : m;
+      entry.byModel[name] = (entry.byModel[name] ?? 0) + num(v?.metrics?.spend);
+    }
     byDate.set(date, entry);
 
     if (date >= monthStartYmd && date <= endYmd) {
@@ -615,7 +621,7 @@ export async function fetchLiteLlmSpend(days: number): Promise<LiteLlmSpend> {
   for (let i = days - 1; i >= 0; i--) {
     const ymd = localYmd(new Date(b.today.getFullYear(), b.today.getMonth(), b.today.getDate() - i));
     const e = b.byDate.get(ymd);
-    daily.push({ date: ymd, cost: e?.cost ?? 0, requests: e?.requests ?? 0, byModel: e?.byModel ?? {} });
+    daily.push({ date: ymd, cost: e?.cost ?? 0, requests: e?.requests ?? 0, successful: e?.successful ?? 0, byModel: e?.byModel ?? {} });
   }
   return {
     monthLabel: b.monthLabel,

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -449,8 +449,12 @@ export interface LiteLlmSpend {
   monthLabel: string;        // current month, e.g. "Jun 2026"
   monthToDate: number;       // total billed from the 1st → today
   monthRequests: number;
+  monthSuccessful: number;   // successful requests this month
+  monthFailed: number;       // failed requests this month
+  monthTokens: { prompt: number; completion: number; cacheRead: number; cacheCreate: number };
   prevMonthLabel: string;    // previous month, e.g. "May"
   prevMonthToDate: number;   // previous month, 1st → same day-of-month (same-period comparison)
+  lifetime: { user: number; key: number }; // lifetime spend (user across all keys / this key)
   // `days` calendar days incl. today, oldest→newest, zero-filled. Per-day cost,
   // request count, and per-model spend (for the hover breakdown).
   daily: { date: string; cost: number; requests: number; byModel: Record<string, number> }[];
@@ -462,6 +466,9 @@ interface LiteLlmBase {
   monthLabel: string;
   monthToDate: number;
   monthRequests: number;
+  monthSuccessful: number;
+  monthFailed: number;
+  monthTokens: { prompt: number; completion: number; cacheRead: number; cacheCreate: number };
   prevMonthLabel: string;
   prevMonthToDate: number;
 }
@@ -505,35 +512,51 @@ async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
   if (cachedLiteLlmBase && cachedLiteLlmBase.key === cacheKey && Date.now() - cachedLiteLlmBase.fetchedAt < LITELLM_TTL)
     return cachedLiteLlmBase.data;
 
-  const url = `${base}/user/daily/activity?start_date=${startYmd}&end_date=${endYmd}`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (res.status === 401 || res.status === 403)
-    throw new Error('LiteLLM rejected the key for spend read (401/403) — the virtual key may lack spend-view permission.');
-  if (res.status === 404)
-    throw new Error('LiteLLM spend endpoint not found (404) — the gateway may not expose /user/daily/activity.');
-  if (!res.ok) throw new Error(`LiteLLM spend fetch failed: ${res.status} ${res.statusText}`);
-
-  const json: any = await res.json();
-  const byDate = new Map<string, { cost: number; requests: number; byModel: Record<string, number> }>();
-  for (const r of Array.isArray(json?.results) ? json.results : []) {
-    if (!r?.date) continue;
-    const date = String(r.date);
-    const entry = byDate.get(date) ?? { cost: 0, requests: 0, byModel: {} };
-    entry.cost += num(r?.metrics?.spend);
-    entry.requests += num(r?.metrics?.api_requests);
-    const models = r?.breakdown?.models ?? {};
-    for (const [m, v] of Object.entries<any>(models)) entry.byModel[m] = (entry.byModel[m] ?? 0) + num(v?.spend);
-    byDate.set(date, entry);
+  // /user/daily/activity is paginated (page_size default 50). Use a large page_size
+  // and follow has_more so month-to-date / daily aren't undercounted. (We don't pass
+  // `timezone`: this gateway validates it as an integer UTC offset, not a tz name, and
+  // the totals we sum are tz-independent — so day bucketing stays the gateway default.)
+  const headers = { Authorization: `Bearer ${token}`, Accept: 'application/json' };
+  const results: any[] = [];
+  for (let page = 1; page <= 20; page++) {
+    const url = `${base}/user/daily/activity?start_date=${startYmd}&end_date=${endYmd}&page=${page}&page_size=1000`;
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(15_000) });
+    if (page === 1 && (res.status === 401 || res.status === 403))
+      throw new Error('LiteLLM rejected the key for spend read (401/403) — the virtual key may lack spend-view permission.');
+    if (page === 1 && res.status === 404)
+      throw new Error('LiteLLM spend endpoint not found (404) — the gateway may not expose /user/daily/activity.');
+    if (!res.ok) throw new Error(`LiteLLM spend fetch failed: ${res.status} ${res.statusText}`);
+    const json: any = await res.json();
+    if (Array.isArray(json?.results)) results.push(...json.results);
+    if (!json?.metadata?.has_more) break;
   }
 
   // YYYY-MM-DD sorts lexicographically, so date-string range checks work directly.
-  let monthToDate = 0, monthRequests = 0, prevMonthToDate = 0;
-  for (const [date, m] of byDate) {
-    if (date >= monthStartYmd && date <= endYmd) { monthToDate += m.cost; monthRequests += m.requests; }
-    if (date >= startYmd && date <= prevEndYmd) prevMonthToDate += m.cost;
+  const byDate = new Map<string, { cost: number; requests: number; byModel: Record<string, number> }>();
+  let monthToDate = 0, monthRequests = 0, monthSuccessful = 0, monthFailed = 0, prevMonthToDate = 0;
+  const monthTokens = { prompt: 0, completion: 0, cacheRead: 0, cacheCreate: 0 };
+  for (const r of results) {
+    const date = String(r?.date ?? '');
+    if (!date) continue;
+    const mx = r?.metrics ?? {};
+    const entry = byDate.get(date) ?? { cost: 0, requests: 0, byModel: {} };
+    entry.cost += num(mx.spend);
+    entry.requests += num(mx.api_requests);
+    const models = r?.breakdown?.models ?? {};
+    for (const [m, v] of Object.entries<any>(models)) entry.byModel[m] = (entry.byModel[m] ?? 0) + num(v?.spend);
+    byDate.set(date, entry);
+
+    if (date >= monthStartYmd && date <= endYmd) {
+      monthToDate += num(mx.spend);
+      monthRequests += num(mx.api_requests);
+      monthSuccessful += num(mx.successful_requests);
+      monthFailed += num(mx.failed_requests);
+      monthTokens.prompt += num(mx.prompt_tokens);
+      monthTokens.completion += num(mx.completion_tokens);
+      monthTokens.cacheRead += num(mx.cache_read_input_tokens);
+      monthTokens.cacheCreate += num(mx.cache_creation_input_tokens);
+    }
+    if (date >= startYmd && date <= prevEndYmd) prevMonthToDate += num(mx.spend);
   }
 
   const data: LiteLlmBase = {
@@ -542,6 +565,9 @@ async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
     monthLabel: `${MONTH_ABBR[monthStart.getMonth()]} ${monthStart.getFullYear()}`,
     monthToDate,
     monthRequests,
+    monthSuccessful,
+    monthFailed,
+    monthTokens,
     prevMonthLabel: MONTH_ABBR[prevMonthStart.getMonth()],
     prevMonthToDate,
   };
@@ -549,10 +575,42 @@ async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
   return data;
 }
 
+const ACCOUNT_TTL = 30 * 60 * 1000; // 30 min — lifetime spend moves slowly
+let cachedLiteLlmAccount: { data: { user: number; key: number }; fetchedAt: number } | null = null;
+
+/**
+ * Lifetime spend from the self-scoped /user/info (the user, across all their keys)
+ * and /key/info (this key). Degrades to zeros on any error — never throws, so it
+ * can't break the spend response.
+ */
+async function fetchLiteLlmAccount(): Promise<{ user: number; key: number }> {
+  if (cachedLiteLlmAccount && Date.now() - cachedLiteLlmAccount.fetchedAt < ACCOUNT_TTL) return cachedLiteLlmAccount.data;
+  const base = litellmBaseUrl();
+  const token = litellmAuthToken();
+  if (!base || !token) return { user: 0, key: 0 };
+  const headers = { Authorization: `Bearer ${token}`, Accept: 'application/json' };
+  const get = async (path: string): Promise<any> => {
+    try {
+      const r = await fetch(`${base}${path}`, { headers, signal: AbortSignal.timeout(15_000) });
+      return r.ok ? await r.json() : null;
+    } catch {
+      return null;
+    }
+  };
+  const [u, k] = await Promise.all([get('/user/info'), get('/key/info')]);
+  const data = {
+    user: num(u?.user_info?.spend ?? u?.spend),
+    key: num(k?.info?.spend ?? k?.spend),
+  };
+  cachedLiteLlmAccount = { data, fetchedAt: Date.now() };
+  return data;
+}
+
 /** Actual billed spend: month-to-date, previous-month same-period total, and the
  *  last `days` calendar days (incl. today, zero-filled) with per-model breakdown. */
 export async function fetchLiteLlmSpend(days: number): Promise<LiteLlmSpend> {
   const b = await fetchLiteLlmBase();
+  const lifetime = await fetchLiteLlmAccount();
   const daily: LiteLlmSpend['daily'] = [];
   for (let i = days - 1; i >= 0; i--) {
     const ymd = localYmd(new Date(b.today.getFullYear(), b.today.getMonth(), b.today.getDate() - i));
@@ -563,8 +621,12 @@ export async function fetchLiteLlmSpend(days: number): Promise<LiteLlmSpend> {
     monthLabel: b.monthLabel,
     monthToDate: b.monthToDate,
     monthRequests: b.monthRequests,
+    monthSuccessful: b.monthSuccessful,
+    monthFailed: b.monthFailed,
+    monthTokens: b.monthTokens,
     prevMonthLabel: b.prevMonthLabel,
     prevMonthToDate: b.prevMonthToDate,
+    lifetime,
     daily,
   };
 }

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -398,3 +398,174 @@ export async function fetchLiveProfile(): Promise<any> {
   return data;
 }
 
+// ── LiteLLM gateway: actual billed cost ──────────────────────────────────────
+// When Claude Code runs through a LiteLLM proxy, the gateway tracks the *real*
+// per-request cost. The dashboard surfaces it next to the local estimate. Reuses
+// the same ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN the AI feature uses, with
+// optional dedicated LITELLM_BASE_URL / LITELLM_API_KEY overrides (for a key that
+// has spend-view permission, when the chat key doesn't).
+
+/** Strip a trailing slash and/or a trailing /v1 (same normalization as ai.ts). */
+function normalizeBaseUrl(raw: string): string {
+  return raw.trim().replace(/\/+$/, '').replace(/\/v1$/, '');
+}
+
+/** LiteLLM gateway base URL — LITELLM_BASE_URL, else ANTHROPIC_BASE_URL. '' if neither. */
+function litellmBaseUrl(): string {
+  const raw = process.env.LITELLM_BASE_URL || process.env.ANTHROPIC_BASE_URL || '';
+  return raw ? normalizeBaseUrl(raw) : '';
+}
+
+/** Virtual-key bearer for the gateway — LITELLM_API_KEY, else ANTHROPIC_AUTH_TOKEN. */
+function litellmAuthToken(): string {
+  return (process.env.LITELLM_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN || '').trim();
+}
+
+/** Anthropic's own hosts — a base URL pointing here is NOT a third-party gateway. */
+function isAnthropicHost(host: string): boolean {
+  return /(^|\.)anthropic\.com$/i.test(host) || /(^|\.)claude\.ai$/i.test(host);
+}
+
+/**
+ * Detect whether a LiteLLM (or compatible) gateway is configured: a non-Anthropic
+ * base URL host plus an auth token. Pure env read (no network) — safe to call from
+ * /api/config. The frontend gates all LiteLLM UI on `available`.
+ */
+export function detectLitellm(): { available: boolean; gatewayHost: string } {
+  const base = litellmBaseUrl();
+  const token = litellmAuthToken();
+  if (!base || !token) return { available: false, gatewayHost: '' };
+  let host = '';
+  try {
+    host = new URL(base).host;
+  } catch {
+    return { available: false, gatewayHost: '' };
+  }
+  if (!host || isAnthropicHost(host)) return { available: false, gatewayHost: '' };
+  return { available: true, gatewayHost: host };
+}
+
+export interface LiteLlmSpend {
+  monthLabel: string;        // current month, e.g. "Jun 2026"
+  monthToDate: number;       // total billed from the 1st → today
+  monthRequests: number;
+  prevMonthLabel: string;    // previous month, e.g. "May"
+  prevMonthToDate: number;   // previous month, 1st → same day-of-month (same-period comparison)
+  // `days` calendar days incl. today, oldest→newest, zero-filled. Per-day cost,
+  // request count, and per-model spend (for the hover breakdown).
+  daily: { date: string; cost: number; requests: number; byModel: Record<string, number> }[];
+}
+
+interface LiteLlmBase {
+  byDate: Map<string, { cost: number; requests: number; byModel: Record<string, number> }>;
+  today: Date;
+  monthLabel: string;
+  monthToDate: number;
+  monthRequests: number;
+  prevMonthLabel: string;
+  prevMonthToDate: number;
+}
+
+const LITELLM_TTL = 5 * 60 * 1000; // 5 min — billing data moves slowly
+let cachedLiteLlmBase: { key: string; data: LiteLlmBase; fetchedAt: number } | null = null;
+const MONTH_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** Local YYYY-MM-DD (matches the app's local-tz day bucketing). */
+function localYmd(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
+/**
+ * One self-scoped /user/daily/activity fetch covering previous-month-start → today
+ * (enough for month-to-date, the previous-month same-period total, and any daily
+ * window up to 28 days). Cached 5 min by date range — independent of the requested
+ * `days`, so switching the window reuses the cache. Throws distinct messages so the
+ * route can degrade gracefully (no permission / not a LiteLLM gateway / outage).
+ */
+async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
+  const base = litellmBaseUrl();
+  const token = litellmAuthToken();
+  if (!base || !token) throw new Error('LiteLLM gateway not configured');
+
+  const today = new Date();
+  const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+  const prevMonthStart = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+  const prevMonthLastDay = new Date(today.getFullYear(), today.getMonth(), 0).getDate();
+  // Same day-of-month in the previous month, clamped to its last day, for a
+  // fair "same point in the month" comparison.
+  const prevMonthEnd = new Date(today.getFullYear(), today.getMonth() - 1, Math.min(today.getDate(), prevMonthLastDay));
+  const startYmd = localYmd(prevMonthStart);
+  const endYmd = localYmd(today);
+  const monthStartYmd = localYmd(monthStart);
+  const prevEndYmd = localYmd(prevMonthEnd);
+
+  const cacheKey = `${startYmd}|${endYmd}`;
+  if (cachedLiteLlmBase && cachedLiteLlmBase.key === cacheKey && Date.now() - cachedLiteLlmBase.fetchedAt < LITELLM_TTL)
+    return cachedLiteLlmBase.data;
+
+  const url = `${base}/user/daily/activity?start_date=${startYmd}&end_date=${endYmd}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (res.status === 401 || res.status === 403)
+    throw new Error('LiteLLM rejected the key for spend read (401/403) — the virtual key may lack spend-view permission.');
+  if (res.status === 404)
+    throw new Error('LiteLLM spend endpoint not found (404) — the gateway may not expose /user/daily/activity.');
+  if (!res.ok) throw new Error(`LiteLLM spend fetch failed: ${res.status} ${res.statusText}`);
+
+  const json: any = await res.json();
+  const byDate = new Map<string, { cost: number; requests: number; byModel: Record<string, number> }>();
+  for (const r of Array.isArray(json?.results) ? json.results : []) {
+    if (!r?.date) continue;
+    const date = String(r.date);
+    const entry = byDate.get(date) ?? { cost: 0, requests: 0, byModel: {} };
+    entry.cost += num(r?.metrics?.spend);
+    entry.requests += num(r?.metrics?.api_requests);
+    const models = r?.breakdown?.models ?? {};
+    for (const [m, v] of Object.entries<any>(models)) entry.byModel[m] = (entry.byModel[m] ?? 0) + num(v?.spend);
+    byDate.set(date, entry);
+  }
+
+  // YYYY-MM-DD sorts lexicographically, so date-string range checks work directly.
+  let monthToDate = 0, monthRequests = 0, prevMonthToDate = 0;
+  for (const [date, m] of byDate) {
+    if (date >= monthStartYmd && date <= endYmd) { monthToDate += m.cost; monthRequests += m.requests; }
+    if (date >= startYmd && date <= prevEndYmd) prevMonthToDate += m.cost;
+  }
+
+  const data: LiteLlmBase = {
+    byDate,
+    today,
+    monthLabel: `${MONTH_ABBR[monthStart.getMonth()]} ${monthStart.getFullYear()}`,
+    monthToDate,
+    monthRequests,
+    prevMonthLabel: MONTH_ABBR[prevMonthStart.getMonth()],
+    prevMonthToDate,
+  };
+  cachedLiteLlmBase = { key: cacheKey, data, fetchedAt: Date.now() };
+  return data;
+}
+
+/** Actual billed spend: month-to-date, previous-month same-period total, and the
+ *  last `days` calendar days (incl. today, zero-filled) with per-model breakdown. */
+export async function fetchLiteLlmSpend(days: number): Promise<LiteLlmSpend> {
+  const b = await fetchLiteLlmBase();
+  const daily: LiteLlmSpend['daily'] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const ymd = localYmd(new Date(b.today.getFullYear(), b.today.getMonth(), b.today.getDate() - i));
+    const e = b.byDate.get(ymd);
+    daily.push({ date: ymd, cost: e?.cost ?? 0, requests: e?.requests ?? 0, byModel: e?.byModel ?? {} });
+  }
+  return {
+    monthLabel: b.monthLabel,
+    monthToDate: b.monthToDate,
+    monthRequests: b.monthRequests,
+    prevMonthLabel: b.prevMonthLabel,
+    prevMonthToDate: b.prevMonthToDate,
+    daily,
+  };
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { usePolling } from './hooks/usePolling';
 import { useLimits } from './hooks/useLimits';
 import { useSettings } from './hooks/useSettings';
-import type { ActivityData, ModelsData, RecentData, WeeklyData, ToolsData, ClaudeConfig, SessionMeta, LiveUsageData, HeatmapData, ProjectData, InsightsErrors, InsightsRetries, InsightsLanguages, InsightsBranches, InsightsMcp, ComplexityPoint, InsightsYield, InsightsRejections, SubagentStats, LiveSubagents, WorkflowsData, CommandUsageData, FileChurnData, WorkspaceTasksData, InventoryData, VersionInfo, SourcesInfo, UsageSource } from './types';
+import type { ActivityData, ModelsData, RecentData, WeeklyData, ToolsData, ClaudeConfig, SessionMeta, LiveUsageData, HeatmapData, ProjectData, InsightsErrors, InsightsRetries, InsightsLanguages, InsightsBranches, InsightsMcp, ComplexityPoint, InsightsYield, InsightsRejections, SubagentStats, LiveSubagents, WorkflowsData, CommandUsageData, FileChurnData, WorkspaceTasksData, InventoryData, VersionInfo, SourcesInfo, UsageSource, LiteLlmSpendData } from './types';
 import { StatCard } from './components/design-system/atoms/StatCard/StatCard';
 import { BlockGauge } from './components/design-system/organisms/BlockGauge/BlockGauge';
 import { UsageBarChart } from './components/design-system/organisms/UsageBarChart/UsageBarChart';
@@ -26,6 +26,7 @@ import { Section } from './components/design-system/molecules/Section/Section';
 import { SpendingLimits } from './components/design-system/molecules/SpendingLimits/SpendingLimits';
 import { ToggleGroup } from './components/design-system/atoms/ToggleGroup/ToggleGroup';
 import { LegendDot } from './components/design-system/atoms/LegendDot/LegendDot';
+import { LiteLlmDailyChart } from './components/design-system/organisms/LiteLlmDailyChart/LiteLlmDailyChart';
 import { ErrorBreakdown } from './components/design-system/organisms/ErrorBreakdown/ErrorBreakdown';
 import { LanguageBreakdown } from './components/design-system/organisms/LanguageBreakdown/LanguageBreakdown';
 import { BranchBreakdown } from './components/design-system/organisms/BranchBreakdown/BranchBreakdown';
@@ -135,6 +136,16 @@ export default function App() {
   const activity = usePolling<ActivityData>(withSrc('/api/activity'), 30000);
   const tools = usePolling<ToolsData>(withSrc('/api/tools?days=7'), 30000);
   const config = usePolling<ClaudeConfig>('/api/config', 60000);
+  // LiteLLM gateway: actual billed cost (month-to-date + per-day window) shown
+  // beside the local estimate. Gated on detection so Code-only / direct-Anthropic
+  // users poll nothing and see no change. The daily window follows the same
+  // weekDays toggle as the estimate chart.
+  const litellmAvailable = !!config.data?.litellm?.available;
+  const litellmHost = config.data?.litellm?.gatewayHost ?? '';
+  const litellm = usePolling<LiteLlmSpendData>(
+    litellmAvailable ? `/api/usage/litellm?days=${weekDays}` : '',
+    POLL,
+  );
   const sessions = usePolling<SessionMeta[]>(withSrc('/api/sessions'), 10000);
   const liveUsage = usePolling<LiveUsageData>('/api/usage/live', 15000);
   const heatmap = usePolling<HeatmapData>(withSrc('/api/heatmap?days=90'), 60000);
@@ -271,6 +282,9 @@ export default function App() {
 
   // Normalize to cost per day from whatever range is selected
   const costPerDay = (weekly.data?.totals.cost ?? 0) / weekDays;
+  // Actual billed spend from the LiteLLM gateway (null on error / not-yet-loaded →
+  // the card is simply hidden, so the dashboard degrades gracefully).
+  const litellmSpend = litellm.data && !('error' in litellm.data) ? litellm.data : null;
   const hasSpendingLimits =
     limits.dailyLimit != null || limits.weeklyLimit != null || limits.monthlyLimit != null;
 
@@ -466,6 +480,24 @@ export default function App() {
           {/* ── TRENDS TAB ── */}
           {activeTab === 'trends' && (
             <>
+              {/* Window selector — drives the cost stat cards, the estimate chart,
+                  and (when present) the LiteLLM actual-billed chart. */}
+              <div className="flex items-center justify-between">
+                <span className="text-xs uppercase tracking-wider text-zinc-500">Spending · last {weekDays} days</span>
+                <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
+                  {[7, 14, 21, 28].map((d) => (
+                    <button
+                      key={d}
+                      onClick={() => setWeekDays(d)}
+                      className={`px-2.5 py-1 text-xs tabular-nums transition-colors ${
+                        weekDays === d ? 'bg-clay-500/20 text-clay-400' : 'text-zinc-500 hover:text-zinc-300'
+                      }`}
+                    >
+                      {d / 7}w
+                    </button>
+                  ))}
+                </div>
+              </div>
               {/* Cost stat cards */}
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
                 {weekly.loading ? (
@@ -481,7 +513,11 @@ export default function App() {
                       label={`Est. equivalent cost · ${weekDays}d`}
                       value={usd(weekly.data?.totals.cost ?? 0)}
                       sub={topModel ? `top: ${shortModel(topModel.model)}` : undefined}
-                      help="What this usage would cost at Anthropic's pay-as-you-go API rates. Your subscription has no per-token bill — this is a reference figure only."
+                      help={
+                        litellmAvailable
+                          ? "Estimated from your local logs at Anthropic's public API rates — a reference figure. Compare it with “Actual billed” (your gateway's real charge): the two differ because the gateway also bills failed/retried requests, uses calendar-day windows, and reflects a more up-to-date snapshot."
+                          : "What this usage would cost at Anthropic's pay-as-you-go API rates. Your subscription has no per-token bill — this is a reference figure only."
+                      }
                     />
                     <StatCard
                       label={`Effective tokens · last ${weekDays} days`}
@@ -510,6 +546,63 @@ export default function App() {
                 )}
               </div>
 
+              {/* Actual billed (LiteLLM gateway): month-to-date + per-day window,
+                  side by side. Gated + degrades silently when the gateway errors. */}
+              {litellmAvailable && litellmSpend && (() => {
+                const daily = litellmSpend.daily;
+                const windowTotal = daily.reduce((s, d) => s + d.cost, 0);
+                const prev = litellmSpend.prevMonthToDate;
+                const monthDelta = prev > 0 ? Math.round(((litellmSpend.monthToDate - prev) / prev) * 100) : null;
+                return (
+                  <Section
+                    title="Actual billed"
+                    help="Real cost billed by your LiteLLM gateway, from its /user/daily/activity report. Month-to-date covers the 1st of the month → today; the daily view breaks out each calendar day in the selected window, including today. May exceed the estimate because the gateway also bills failed/retried requests."
+                    right={
+                      litellmHost ? (
+                        <span className="text-xs text-zinc-500">
+                          gateway <span className="font-semibold text-zinc-300">{litellmHost}</span>
+                        </span>
+                      ) : undefined
+                    }
+                  >
+                    <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
+                      {/* Month-to-date */}
+                      <div className="flex flex-col justify-center rounded-xl bg-emerald-500/[0.06] p-5 ring-1 ring-emerald-500/20">
+                        <div className="text-[11px] font-medium uppercase tracking-wider text-emerald-300/80">
+                          {litellmSpend.monthLabel} · month-to-date
+                        </div>
+                        <div className="mt-1.5 text-4xl font-bold tabular-nums text-emerald-400">
+                          {usd(litellmSpend.monthToDate)}
+                        </div>
+                        <div className="mt-1 text-sm text-zinc-400">
+                          {litellmSpend.monthRequests.toLocaleString()} requests since the 1st
+                        </div>
+                        {monthDelta !== null && (
+                          <div className="mt-1.5 text-xs text-zinc-500">
+                            <span className={monthDelta >= 0 ? 'text-red-400' : 'text-emerald-400'}>
+                              {monthDelta >= 0 ? '▲' : '▼'} {Math.abs(monthDelta)}%
+                            </span>{' '}
+                            vs {usd(prev)} in {litellmSpend.prevMonthLabel} (same point)
+                          </div>
+                        )}
+                      </div>
+                      {/* Daily breakdown over the selected window */}
+                      <div className="lg:col-span-2">
+                        <div className="mb-3 flex items-center justify-between">
+                          <span className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+                            Last {weekDays} days
+                          </span>
+                          <span className="text-xs text-zinc-400">
+                            <span className="font-semibold text-zinc-200">{usd(windowTotal)}</span> total
+                          </span>
+                        </div>
+                        <LiteLlmDailyChart days={daily} />
+                      </div>
+                    </div>
+                  </Section>
+                );
+              })()}
+
               {/* Sources split (Code vs Cowork) — only under the All filter, where
                   the split is meaningful (a single-surface filter zeroes the other). */}
               {coworkAvailable && source === 'all' && weekly.data?.bySource && (() => {
@@ -524,7 +617,7 @@ export default function App() {
                     help="Split of effective tokens (and equivalent cost) between Claude Code (CLI) and Cowork (desktop local-agent mode) over the selected window."
                   >
                     <div className="flex items-center gap-4">
-                      <div className="flex flex-1 h-3 overflow-hidden rounded-full bg-ink-800 ring-1 ring-white/5">
+                      <div className="flex flex-1 h-3 overflow-hidden rounded-full bg-ink-800 ring-1 ring-white/10">
                         <div style={{ width: `${codePct}%`, backgroundColor: SOURCE_COLOR.code }} />
                         <div style={{ width: `${100 - codePct}%`, backgroundColor: SOURCE_COLOR.cowork }} />
                       </div>
@@ -550,7 +643,7 @@ export default function App() {
                 return (
                   <Section
                     title={`Last ${weekDays} days · daily ${dailyMetric} by model`}
-                    help="Daily tokens (or equivalent cost), stacked by model. The dotted segment past today is a projection from your recent daily average. Toggle tokens/cost and the window on the right."
+                    help="Daily tokens (or equivalent cost), stacked by model. The dotted segment past today is a projection from your recent daily average. Toggle tokens/cost on the right; change the window with the selector at the top."
                     aiSection="trends"
                     aiDisabled={aiDisabled}
                     aiLoading={ai.states.get('trends')?.loading}
@@ -591,21 +684,6 @@ export default function App() {
                               }`}
                             >
                               {m}
-                            </button>
-                          ))}
-                        </div>
-                        <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
-                          {[7, 14, 21, 28].map((d) => (
-                            <button
-                              key={d}
-                              onClick={() => setWeekDays(d)}
-                              className={`px-2.5 py-1 text-xs tabular-nums transition-colors ${
-                                weekDays === d
-                                  ? 'bg-clay-500/20 text-clay-400'
-                                  : 'text-zinc-500 hover:text-zinc-300'
-                              }`}
-                            >
-                              {d / 7}w
                             </button>
                           ))}
                         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -567,6 +567,12 @@ export default function App() {
                 const windowTotal = daily.reduce((s, d) => s + d.cost, 0);
                 const prev = litellmSpend.prevMonthToDate;
                 const monthDelta = prev > 0 ? Math.round(((litellmSpend.monthToDate - prev) / prev) * 100) : null;
+                const fail = litellmSpend.monthFailed;
+                const reqTotal = litellmSpend.monthSuccessful + fail;
+                const successPct = reqTotal > 0 ? (litellmSpend.monthSuccessful / reqTotal) * 100 : null;
+                const tok = litellmSpend.monthTokens;
+                const tokTotal = tok.prompt + tok.completion + tok.cacheRead + tok.cacheCreate;
+                const tokPct = (n: number) => (tokTotal > 0 ? `${(n / tokTotal) * 100}%` : '0%');
                 return (
                   <Section
                     title="Actual billed"
@@ -599,6 +605,19 @@ export default function App() {
                             vs {usd(prev)} in {litellmSpend.prevMonthLabel} (same point)
                           </div>
                         )}
+                        {successPct !== null && (
+                          <div className="mt-1.5 text-xs text-zinc-500">
+                            <span className={successPct >= 99 ? 'text-emerald-400' : successPct >= 95 ? 'text-amber-400' : 'text-red-400'}>
+                              {successPct.toFixed(1)}% success
+                            </span>
+                            {fail > 0 && <span className="text-zinc-600"> · {fail.toLocaleString()} failed</span>}
+                          </div>
+                        )}
+                        {litellmSpend.lifetime.user > 0 && (
+                          <div className="mt-1 text-xs text-zinc-600">
+                            lifetime · <span className="text-zinc-400">{usd(litellmSpend.lifetime.user)}</span>
+                          </div>
+                        )}
                       </div>
                       {/* Daily breakdown over the selected window */}
                       <div className="lg:col-span-2">
@@ -613,6 +632,28 @@ export default function App() {
                         <LiteLlmDailyChart days={daily} />
                       </div>
                     </div>
+                    {tokTotal > 0 && (
+                      <div className="mt-5 border-t border-white/10 pt-4">
+                        <div className="mb-2 flex items-center justify-between">
+                          <span className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+                            Token mix · {litellmSpend.monthLabel}
+                          </span>
+                          <span className="text-xs text-zinc-400">{compact(tokTotal)} total</span>
+                        </div>
+                        <div className="flex h-2.5 overflow-hidden rounded-full bg-ink-800 ring-1 ring-white/10">
+                          <div style={{ width: tokPct(tok.prompt), backgroundColor: '#d97757' }} />
+                          <div style={{ width: tokPct(tok.completion), backgroundColor: '#6366f1' }} />
+                          <div style={{ width: tokPct(tok.cacheCreate), backgroundColor: '#f59e0b' }} />
+                          <div style={{ width: tokPct(tok.cacheRead), backgroundColor: '#10b981' }} />
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1.5">
+                          <LegendDot color="#d97757" label={`Input · ${compact(tok.prompt)}`} size="sm" />
+                          <LegendDot color="#6366f1" label={`Output · ${compact(tok.completion)}`} size="sm" />
+                          <LegendDot color="#f59e0b" label={`Cache write · ${compact(tok.cacheCreate)}`} size="sm" />
+                          <LegendDot color="#10b981" label={`Cache read · ${compact(tok.cacheRead)}`} size="sm" />
+                        </div>
+                      </div>
+                    )}
                   </Section>
                 );
               })()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,6 +285,18 @@ export default function App() {
   // Actual billed spend from the LiteLLM gateway (null on error / not-yet-loaded →
   // the card is simply hidden, so the dashboard degrades gracefully).
   const litellmSpend = litellm.data && !('error' in litellm.data) ? litellm.data : null;
+  // Real billed cost (today / last 7 days / month-to-date) for the Live-tab spend
+  // widgets, when a LiteLLM gateway is configured — so API SPENDING and the daily-cap
+  // ring reflect what the gateway actually bills instead of the local-logs estimate.
+  // Today = the most recent daily entry; week = the last 7 of the daily series.
+  const litellmActual = litellmAvailable && litellmSpend
+    ? {
+        today: litellmSpend.daily[litellmSpend.daily.length - 1]?.cost ?? 0,
+        week: litellmSpend.daily.slice(-7).reduce((s, d) => s + d.cost, 0),
+        month: litellmSpend.monthToDate,
+        note: litellmHost ? `actual · via ${litellmHost}` : 'actual billed',
+      }
+    : null;
   const hasSpendingLimits =
     limits.dailyLimit != null || limits.weeklyLimit != null || limits.monthlyLimit != null;
 
@@ -415,6 +427,7 @@ export default function App() {
                     isApi={isApi}
                     costPerDay={costPerDay}
                     dailyLimit={limits.dailyLimit}
+                    todayActualCost={litellmActual?.today ?? null}
                   />
                 )}
                 <div className="flex flex-col lg:col-span-2">
@@ -462,6 +475,7 @@ export default function App() {
                   costPerDay={costPerDay}
                   weekCost={weekly.data?.totals.cost}
                   alwaysShow={isApi}
+                  actual={litellmActual ?? undefined}
                 />
               )}
             </>

--- a/src/components/design-system/molecules/ExportButton/ExportButton.tsx
+++ b/src/components/design-system/molecules/ExportButton/ExportButton.tsx
@@ -35,13 +35,13 @@ export function ExportButton({ label = 'Export', getData }: ExportButtonProps) {
           <div className="absolute right-0 top-8 z-20 min-w-[120px] rounded-xl border border-white/10 bg-ink-700 shadow-2xl py-1">
             <button
               onClick={() => handleExport('csv')}
-              className="w-full px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-white/5 transition-colors"
+              className="w-full px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-white/10 transition-colors"
             >
               📄 Export CSV
             </button>
             <button
               onClick={() => handleExport('json')}
-              className="w-full px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-white/5 transition-colors"
+              className="w-full px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-white/10 transition-colors"
             >
               {'{ }'} Export JSON
             </button>

--- a/src/components/design-system/molecules/Modal/Modal.tsx
+++ b/src/components/design-system/molecules/Modal/Modal.tsx
@@ -28,12 +28,12 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
         style={{ animation: 'agent-enter 0.2s ease-out both' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between gap-3 border-b border-white/5 px-5 py-3 flex-none">
+        <div className="flex items-center justify-between gap-3 border-b border-white/10 px-5 py-3 flex-none">
           <div className="min-w-0 flex-1">{title}</div>
           <button
             onClick={onClose}
             aria-label="Close"
-            className="flex-none rounded-lg px-2 py-1 text-zinc-500 hover:text-zinc-200 hover:bg-white/5 transition-colors text-sm"
+            className="flex-none rounded-lg px-2 py-1 text-zinc-500 hover:text-zinc-200 hover:bg-white/10 transition-colors text-sm"
           >
             ✕
           </button>

--- a/src/components/design-system/molecules/SpendingLimits/SpendingLimits.tsx
+++ b/src/components/design-system/molecules/SpendingLimits/SpendingLimits.tsx
@@ -4,13 +4,21 @@ import { usd } from '@/lib/format';
 import { spendingBarColor } from './utils';
 import type { SpendingLimitsProps } from './types';
 
-export function SpendingLimits({ limits, costPerDay, weekCost, alwaysShow = false }: SpendingLimitsProps) {
+export function SpendingLimits({ limits, costPerDay, weekCost, alwaysShow = false, actual }: SpendingLimitsProps) {
   const weeklyCost = weekCost ?? costPerDay * 7;
-  const allRows = [
-    { label: 'Today', cost: costPerDay, limit: limits.dailyLimit },
-    { label: 'This week', cost: weeklyCost, limit: limits.weeklyLimit },
-    { label: 'Monthly (est.)', cost: costPerDay * 30, limit: limits.monthlyLimit },
-  ];
+  // When `actual` is provided, show the gateway's real billed cost (and exact
+  // month-to-date); otherwise fall back to the local-logs estimate.
+  const allRows = actual
+    ? [
+        { label: 'Today', cost: actual.today, limit: limits.dailyLimit },
+        { label: 'This week', cost: actual.week, limit: limits.weeklyLimit },
+        { label: 'This month', cost: actual.month, limit: limits.monthlyLimit },
+      ]
+    : [
+        { label: 'Today', cost: costPerDay, limit: limits.dailyLimit },
+        { label: 'This week', cost: weeklyCost, limit: limits.weeklyLimit },
+        { label: 'Monthly (est.)', cost: costPerDay * 30, limit: limits.monthlyLimit },
+      ];
 
   // API mode shows every row (the spend is the bill); subscription mode only
   // shows rows the user has set a cap for.
@@ -22,9 +30,15 @@ export function SpendingLimits({ limits, costPerDay, weekCost, alwaysShow = fals
       <div className="mb-4 flex items-center justify-between">
         <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-500">
           API Spending
-          <InfoTip text="Your estimated equivalent API spend against the daily/weekly/monthly USD caps you set (⚙ Settings). Caps are stored locally in your browser — this is a budgeting aid, not a real bill." />
+          <InfoTip
+            text={
+              actual
+                ? 'Real cost billed by your LiteLLM gateway (today, last 7 days, and month-to-date) against the daily/weekly/monthly USD caps you set in ⚙ Settings. Caps are stored locally in your browser.'
+                : 'Your estimated equivalent API spend against the daily/weekly/monthly USD caps you set (⚙ Settings). Caps are stored locally in your browser — this is a budgeting aid, not a real bill.'
+            }
+          />
         </h3>
-        <span className="text-xs text-zinc-600">estimated from local logs</span>
+        <span className="text-xs text-zinc-600">{actual ? actual.note : 'estimated from local logs'}</span>
       </div>
       <div className="space-y-4">
         {rows.map(({ label, cost, limit }) => {

--- a/src/components/design-system/molecules/SpendingLimits/types.ts
+++ b/src/components/design-system/molecules/SpendingLimits/types.ts
@@ -7,4 +7,7 @@ export interface SpendingLimitsProps {
   weekCost?: number;
   /** Always render the spend rows (even without caps) — used in API mode. */
   alwaysShow?: boolean;
+  /** When set, rows show the real billed cost (e.g. from a LiteLLM gateway) against
+   *  the caps, instead of the local-logs estimate, and the header note reflects it. */
+  actual?: { today: number; week: number; month: number; note: string };
 }

--- a/src/components/design-system/organisms/AgentActivity/AgentActivity.tsx
+++ b/src/components/design-system/organisms/AgentActivity/AgentActivity.tsx
@@ -40,7 +40,7 @@ function ModelChip({ model }: { model: string }) {
 
 function WorkingBar() {
   return (
-    <div className="relative h-0.5 w-full overflow-hidden rounded-full bg-white/5">
+    <div className="relative h-0.5 w-full overflow-hidden rounded-full bg-white/10">
       <div
         className="absolute inset-y-0 w-1/3 rounded-full"
         style={{
@@ -183,7 +183,7 @@ function MainAgentCard({
   return (
     <div
       className={`card flex flex-col gap-2 p-4 border transition-all duration-500 ${
-        working ? 'border-clay-500/15' : 'border-white/5 opacity-60 saturate-50'
+        working ? 'border-clay-500/15' : 'border-white/10 opacity-60 saturate-50'
       }`}
       style={{ animation: 'agent-enter 0.3s ease-out both' }}
     >
@@ -239,7 +239,7 @@ function GroupLabel({ children }: { children: string }) {
 // in parallel right now. Pulses while anything is active.
 function CountChip({ count, label, pulse }: { count: number; label: string; pulse?: boolean }) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/5 px-2.5 py-1 text-xs font-semibold tabular-nums text-zinc-300 ring-1 ring-white/10">
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-2.5 py-1 text-xs font-semibold tabular-nums text-zinc-300 ring-1 ring-white/10">
       {pulse && <span className="pulse-dot flex-none" />}
       {count} {label}
     </span>

--- a/src/components/design-system/organisms/AiChat/AiChat.tsx
+++ b/src/components/design-system/organisms/AiChat/AiChat.tsx
@@ -14,7 +14,7 @@ const SUGGESTIONS = [
 const BACKEND_NOTE: Record<string, string> = {
   cli: 'Answers come from your local Claude CLI (claude -p).',
   api: 'Answers come from the Claude.ai API using your local token.',
-  apikey: 'Answers come from the Anthropic API (ANTHROPIC_API_KEY).',
+  apikey: 'Answers come from the Anthropic Messages API (ANTHROPIC_AUTH_TOKEN/ANTHROPIC_BASE_URL or ANTHROPIC_API_KEY).',
   none: '',
 };
 
@@ -119,7 +119,7 @@ export function AiChat({ status, config, onChangeConfig, onAsked, onOpenSettings
                     ? 'whitespace-pre-line bg-clay-500/20 text-zinc-100'
                     : m.error
                       ? 'whitespace-pre-line bg-red-500/10 text-red-300 ring-1 ring-red-500/20'
-                      : 'bg-ink-800/70 text-zinc-300 ring-1 ring-white/5'
+                      : 'bg-ink-800/70 text-zinc-300 ring-1 ring-white/10'
                 }`}
               >
                 {m.role === 'assistant' && !m.error ? (

--- a/src/components/design-system/organisms/BlockGauge/BlockGauge.tsx
+++ b/src/components/design-system/organisms/BlockGauge/BlockGauge.tsx
@@ -219,7 +219,7 @@ export function BlockGauge({ block, liveUsage, isApi = false, costPerDay = 0, da
 
         {/* Burn rate row */}
         {burnRateStr && (
-          <div className="flex justify-between pt-1 mt-1 border-t border-white/5" style={{ color: burnColor }}>
+          <div className="flex justify-between pt-1 mt-1 border-t border-white/10" style={{ color: burnColor }}>
             <span className="text-zinc-500">Burn rate</span>
             <span className="tabular-nums font-semibold text-xs">
               {burnRateStr}

--- a/src/components/design-system/organisms/BlockGauge/BlockGauge.tsx
+++ b/src/components/design-system/organisms/BlockGauge/BlockGauge.tsx
@@ -5,7 +5,7 @@ import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import type { BlockGaugeProps } from './types';
 import { BLOCK_MS, DEFAULT_BLOCK_LIMIT, formatRemaining } from './utils';
 
-export function BlockGauge({ block, liveUsage, isApi = false, costPerDay = 0, dailyLimit = null }: BlockGaugeProps) {
+export function BlockGauge({ block, liveUsage, isApi = false, costPerDay = 0, dailyLimit = null, todayActualCost = null }: BlockGaugeProps) {
   const [, force] = useState(0);
   useEffect(() => {
     const id = setInterval(() => force((n) => n + 1), 1000);
@@ -26,7 +26,10 @@ export function BlockGauge({ block, liveUsage, isApi = false, costPerDay = 0, da
   // otherwise it stays empty (informational, not a limit gauge).
   const cost = block?.totals.cost ?? 0;
   const prevCost = block?.prevTotals.cost ?? 0;
-  const capPct = isApi && dailyLimit ? Math.min(100, (costPerDay / dailyLimit) * 100) : null;
+  // Daily-cap ring: prefer real billed spend so far today (gateway) over the
+  // estimated average $/day, so the cap warning reflects actual money spent.
+  const dailySpend = todayActualCost ?? costPerDay;
+  const capPct = isApi && dailyLimit ? Math.min(100, (dailySpend / dailyLimit) * 100) : null;
 
   const tokPct = hasLive
     ? liveUsage.five_hour.utilization
@@ -88,7 +91,9 @@ export function BlockGauge({ block, liveUsage, isApi = false, costPerDay = 0, da
   if (isApi) {
     statusBadge = (
       <div className="mt-0.5 text-[10px] text-zinc-500 select-none">
-        Current 5-hour session · estimated from local logs
+        {todayActualCost != null
+          ? '5-hour block (est.) · cap ring = real gateway spend'
+          : 'Current 5-hour session · estimated from local logs'}
       </div>
     );
   } else if (hasLive) {
@@ -128,7 +133,9 @@ export function BlockGauge({ block, liveUsage, isApi = false, costPerDay = 0, da
             align="center"
             text={
               isApi
-                ? "Estimated cost of your current 5-hour usage block, anchored to your most recent session's first message. Dollar figures use Anthropic's published API rates and are computed from local logs. The ring fills against your daily spending cap when one is set in ⚙ Settings."
+                ? todayActualCost != null
+                  ? "The big number is the estimated cost of your current 5-hour block (published API rates, from local logs). The daily-cap ring uses your real billed spend so far today from your LiteLLM gateway — see API Spending below for the real today / week / month figures. Set a daily cap in ⚙ Settings."
+                  : "Estimated cost of your current 5-hour usage block, anchored to your most recent session's first message. Dollar figures use Anthropic's published API rates and are computed from local logs. The ring fills against your daily spending cap when one is set in ⚙ Settings."
                 : "Your current 5-hour usage block, anchored to your most recent session's first message (how Anthropic starts a 5h window). The ring shows % of the live account limit from Claude.ai; rows below show this block's effective tokens, cache reads, reset time and burn rate."
             }
           />

--- a/src/components/design-system/organisms/BlockGauge/types.ts
+++ b/src/components/design-system/organisms/BlockGauge/types.ts
@@ -9,4 +9,7 @@ export interface BlockGaugeProps {
   costPerDay?: number;
   /** Daily USD cap from Settings, if configured. */
   dailyLimit?: number | null;
+  /** Real billed cost so far today (from a LiteLLM gateway). When set, the daily-cap
+   *  ring uses this instead of the estimated costPerDay. */
+  todayActualCost?: number | null;
 }

--- a/src/components/design-system/organisms/ConfigProfile/ConfigProfile.tsx
+++ b/src/components/design-system/organisms/ConfigProfile/ConfigProfile.tsx
@@ -22,19 +22,19 @@ export function ConfigProfile({ config, isApi = false }: ConfigProfileProps) {
       </div>
 
       <div className="grid grid-cols-2 gap-3 mb-4 flex-none">
-        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/5">
+        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/10">
           <span className="text-[11px] text-zinc-500 uppercase tracking-wider block mb-0.5">Default Model</span>
           <span className="text-sm font-semibold text-clay-400 font-mono capitalize">
             {config.model ?? 'sonnet'}
           </span>
         </div>
-        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/5">
+        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/10">
           <span className="text-[11px] text-zinc-500 uppercase tracking-wider block mb-0.5">Effort Level</span>
           <span className="text-sm font-semibold text-emerald-400 font-mono capitalize">
             {config.effortLevel ?? 'medium'}
           </span>
         </div>
-        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/5">
+        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/10">
           <span className="text-[11px] text-zinc-500 uppercase tracking-wider block mb-0.5">
             {isApi ? 'Billing' : 'Subscription'}
           </span>
@@ -49,19 +49,19 @@ export function ConfigProfile({ config, isApi = false }: ConfigProfileProps) {
             {isApi ? 'API · pay-as-you-go' : formatPlan(config.subscriptionType)}
           </span>
         </div>
-        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/5">
+        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/10">
           <span className="text-[11px] text-zinc-500 uppercase tracking-wider block mb-0.5">Rate Limit Tier</span>
           <span className="text-sm font-semibold text-indigo-400 font-mono truncate block" title={isApi ? 'n/a in API mode' : (config.rateLimitTier ?? 'default')}>
             {isApi ? '—' : config.rateLimitTier ? config.rateLimitTier.replace(/_/g, ' ') : 'default'}
           </span>
         </div>
-        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/5">
+        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/10">
           <span className="text-[11px] text-zinc-500 uppercase tracking-wider block mb-0.5">Permission Mode</span>
           <span className="text-sm font-semibold text-amber-400 font-mono capitalize truncate block" title={config.permissions?.defaultMode ?? 'default'}>
             {(config.permissions?.defaultMode ?? 'default').replace(/([a-z])([A-Z])/g, '$1 $2')}
           </span>
         </div>
-        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/5">
+        <div className="rounded-xl bg-ink-700/50 p-3 border border-white/10">
           <span className="text-[11px] text-zinc-500 uppercase tracking-wider block mb-0.5">Auto-Update Channel</span>
           <span className="text-sm font-semibold text-violet-400 font-mono capitalize truncate block" title={config.autoUpdatesChannel ?? 'latest'}>
             {config.autoUpdatesChannel ?? 'latest'}
@@ -70,25 +70,25 @@ export function ConfigProfile({ config, isApi = false }: ConfigProfileProps) {
       </div>
 
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 mb-4 text-xs flex-none">
-        <div className="flex justify-between items-center py-1.5 border-b border-white/5">
+        <div className="flex justify-between items-center py-1.5 border-b border-white/10">
           <span className="text-zinc-400">Voice Mode</span>
           <Badge variant={config.voiceEnabled ? 'success' : 'neutral'}>
             {config.voiceEnabled ? 'Enabled' : 'Disabled'}
           </Badge>
         </div>
-        <div className="flex justify-between items-center py-1.5 border-b border-white/5">
+        <div className="flex justify-between items-center py-1.5 border-b border-white/10">
           <span className="text-zinc-400">Remote Control</span>
           <Badge variant={config.remoteControlAtStartup ? 'success' : 'neutral'}>
             {config.remoteControlAtStartup ? 'Active' : 'Inactive'}
           </Badge>
         </div>
-        <div className="flex justify-between items-center py-1.5 border-b border-white/5">
+        <div className="flex justify-between items-center py-1.5 border-b border-white/10">
           <span className="text-zinc-400">Input Alerts</span>
           <Badge variant={config.inputNeededNotifEnabled ? 'success' : 'neutral'}>
             {config.inputNeededNotifEnabled ? 'On' : 'Off'}
           </Badge>
         </div>
-        <div className="flex justify-between items-center py-1.5 border-b border-white/5">
+        <div className="flex justify-between items-center py-1.5 border-b border-white/10">
           <span className="text-zinc-400">Agent Push</span>
           <Badge variant={config.agentPushNotifEnabled ? 'success' : 'neutral'}>
             {config.agentPushNotifEnabled ? 'On' : 'Off'}
@@ -97,10 +97,10 @@ export function ConfigProfile({ config, isApi = false }: ConfigProfileProps) {
       </div>
 
       <div className="flex items-center gap-2 mb-4 text-[11px] flex-none">
-        <span className="rounded-lg bg-ink-700/50 border border-white/5 px-2.5 py-1 text-zinc-400">
+        <span className="rounded-lg bg-ink-700/50 border border-white/10 px-2.5 py-1 text-zinc-400">
           Plugins <span className="font-semibold text-zinc-200">{pluginCount}</span>
         </span>
-        <span className="rounded-lg bg-ink-700/50 border border-white/5 px-2.5 py-1 text-zinc-400">
+        <span className="rounded-lg bg-ink-700/50 border border-white/10 px-2.5 py-1 text-zinc-400">
           Marketplaces <span className="font-semibold text-zinc-200">{marketplaceCount}</span>
         </span>
       </div>
@@ -111,7 +111,7 @@ export function ConfigProfile({ config, isApi = false }: ConfigProfileProps) {
           <span className="text-xs font-bold uppercase tracking-wider text-zinc-400 mb-1.5 block">
             Authorized Workspaces ({allowedDirs.length})
           </span>
-          <div className="overflow-y-auto max-h-[200px] pr-1 scrollbar-thin divide-y divide-white/5 border border-white/5 rounded-xl bg-ink-700/30 p-2 text-xs">
+          <div className="overflow-y-auto max-h-[200px] pr-1 scrollbar-thin divide-y divide-white/10 border border-white/10 rounded-xl bg-ink-700/30 p-2 text-xs">
             {allowedDirs.length > 0 ? (
               allowedDirs.map((dir, idx) => (
                 <div key={idx} className="py-1.5 font-mono text-zinc-400 truncate" title={dir}>
@@ -129,7 +129,7 @@ export function ConfigProfile({ config, isApi = false }: ConfigProfileProps) {
           <span className="text-xs font-bold uppercase tracking-wider text-zinc-400 mb-1.5 block">
             Approved Command Prefixes ({allowedCommands.length})
           </span>
-          <div className="overflow-y-auto max-h-[200px] pr-1 scrollbar-thin divide-y divide-white/5 border border-white/5 rounded-xl bg-ink-700/30 p-2 text-xs">
+          <div className="overflow-y-auto max-h-[200px] pr-1 scrollbar-thin divide-y divide-white/10 border border-white/10 rounded-xl bg-ink-700/30 p-2 text-xs">
             {allowedCommands.length > 0 ? (
               allowedCommands.map((cmd, idx) => (
                 <div key={idx} className="py-1.5 font-mono text-zinc-400 truncate" title={cmd}>

--- a/src/components/design-system/organisms/CostCalculation/CostCalculation.tsx
+++ b/src/components/design-system/organisms/CostCalculation/CostCalculation.tsx
@@ -44,7 +44,7 @@ export function CostCalculation() {
         <div className="lg:col-span-7 overflow-x-auto">
           <table className="w-full text-left text-xs border-collapse">
             <thead>
-              <tr className="border-b border-white/5 text-zinc-500 font-semibold uppercase tracking-wider">
+              <tr className="border-b border-white/10 text-zinc-500 font-semibold uppercase tracking-wider">
                 <th className="py-2.5">Model</th>
                 <th className="py-2.5 text-right">Input / 1M</th>
                 <th className="py-2.5 text-right">Output / 1M</th>
@@ -52,11 +52,11 @@ export function CostCalculation() {
                 <th className="py-2.5 text-right">Cache Read / 1M</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-white/5 text-zinc-300">
+            <tbody className="divide-y divide-white/10 text-zinc-300">
               {currentModels.map((model) => (
                 <tr
                   key={model.name}
-                  className={`hover:bg-white/5 transition-colors cursor-pointer ${
+                  className={`hover:bg-white/10 transition-colors cursor-pointer ${
                     selectedModel.name === model.name ? 'bg-clay-500/10 text-clay-400 font-medium' : ''
                   }`}
                   onClick={() => setSelectedModel(model)}
@@ -74,7 +74,7 @@ export function CostCalculation() {
                 legacyModels.map((model) => (
                   <tr
                     key={model.name}
-                    className={`hover:bg-white/5 transition-colors cursor-pointer ${
+                    className={`hover:bg-white/10 transition-colors cursor-pointer ${
                       selectedModel.name === model.name ? 'bg-clay-500/10 text-clay-400 font-medium' : ''
                     }`}
                     onClick={() => setSelectedModel(model)}
@@ -101,13 +101,13 @@ export function CostCalculation() {
             </button>
           </div>
 
-          <div className="mt-4 rounded-xl bg-ink-700/30 p-3 text-xs text-zinc-400 leading-relaxed border border-white/5">
+          <div className="mt-4 rounded-xl bg-ink-700/30 p-3 text-xs text-zinc-400 leading-relaxed border border-white/10">
             <span className="font-semibold text-zinc-300">💡 Prompt Caching Benefit:</span> Cache reads cost only <strong>10%</strong> of standard input price. Designing your prompts to reuse systemic instructions, codebase maps, or tool schemas leverages this pricing to achieve massive savings.
           </div>
         </div>
 
         {/* Right: Interactive Sandbox Calculator */}
-        <div className="lg:col-span-5 flex flex-col rounded-xl bg-ink-700/50 p-5 border border-white/5">
+        <div className="lg:col-span-5 flex flex-col rounded-xl bg-ink-700/50 p-5 border border-white/10">
           <div className="mb-4 flex items-center justify-between gap-4">
             <div>
               <span className="text-xs font-bold uppercase tracking-wider text-zinc-400">Interactive Cost Calculator</span>
@@ -233,14 +233,14 @@ export function CostCalculation() {
           </div>
 
           {/* Formula & Total */}
-          <div className="mt-5 pt-4 border-t border-white/5">
+          <div className="mt-5 pt-4 border-t border-white/10">
             <div className="flex items-center justify-between">
               <span className="text-xs font-semibold text-zinc-400">Calculated Cost</span>
               <span className="text-xl font-bold text-clay-400 tabular-nums">{usd(calculateCost())}</span>
             </div>
 
             {/* Visual Formula breakdown */}
-            <div className="mt-3 font-mono text-[10px] text-zinc-500 bg-ink-900/80 p-2.5 rounded border border-white/5 leading-relaxed overflow-x-auto whitespace-nowrap">
+            <div className="mt-3 font-mono text-[10px] text-zinc-500 bg-ink-900/80 p-2.5 rounded border border-white/10 leading-relaxed overflow-x-auto whitespace-nowrap">
               <div>
                 ({compact(inputTokens)} × ${selectedModel.input}/M) +
                 ({compact(outputTokens)} × ${selectedModel.output}/M) +
@@ -249,7 +249,7 @@ export function CostCalculation() {
                 ({compact(cacheWriteTokens)} × ${selectedModel.cacheWrite}/M) +
                 ({compact(cacheReadTokens)} × ${selectedModel.cacheRead}/M)
               </div>
-              <div className="mt-1 border-t border-white/5 pt-1 text-zinc-400">
+              <div className="mt-1 border-t border-white/10 pt-1 text-zinc-400">
                 = {usd(calculateCost())}
               </div>
             </div>

--- a/src/components/design-system/organisms/LiteLlmDailyChart/LiteLlmDailyChart.tsx
+++ b/src/components/design-system/organisms/LiteLlmDailyChart/LiteLlmDailyChart.tsx
@@ -1,0 +1,92 @@
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/design-system/molecules/ChartTooltip/ChartTooltip';
+import { usd, shortModel, dayLabel } from '@/lib/format';
+import { modelColor } from '@/lib/palette';
+import type { LiteLlmDailyChartProps, LiteLlmDailyTooltipProps } from './types';
+
+const BAR = '#10b981';
+const BAR_TODAY = '#34d399';
+
+/** Hover card: day total, per-model breakdown (sorted desc), and request count. */
+function DailyTooltip({ active, payload }: LiteLlmDailyTooltipProps) {
+  if (!active || !payload || !payload.length) return null;
+  const d = payload[0].payload;
+  const models = Object.entries(d.byModel)
+    .filter(([, v]) => v > 0)
+    .sort((a, b) => b[1] - a[1]);
+  return (
+    <ChartTooltip minWidth={180}>
+      <div className="mb-2 font-semibold text-zinc-300">
+        {d.full}
+        {d.isToday && <span className="ml-1 font-normal text-emerald-400">· today</span>}
+      </div>
+      <div className="flex items-center justify-between gap-6">
+        <span className="text-zinc-500">Day spend</span>
+        <span className="font-bold text-emerald-400">{usd(d.cost)}</span>
+      </div>
+      {models.length > 0 && (
+        <div className="mt-2 space-y-1.5 border-t border-white/10 pt-2">
+          {models.map(([m, v]) => (
+            <div key={m} className="flex items-center justify-between gap-4">
+              <span className="flex items-center gap-1.5">
+                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: modelColor(m) }} />
+                <span className="text-zinc-300">{shortModel(m)}</span>
+              </span>
+              <span className="font-semibold text-zinc-100">{usd(v)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 border-t border-white/10 pt-2 text-xs text-zinc-500">
+        {d.requests.toLocaleString()} requests
+      </div>
+    </ChartTooltip>
+  );
+}
+
+/** Vertical bar chart of actual daily spend (last 7 days, left→right). Today's
+ *  bar is brighter; hovering a bar reveals the per-model breakdown. */
+export function LiteLlmDailyChart({ days }: LiteLlmDailyChartProps) {
+  const data = days.map((d, i) => {
+    const [y, mo, da] = d.date.split('-').map(Number);
+    const full = dayLabel(new Date(y, mo - 1, da).getTime());
+    return {
+      label: full.split(', ')[1] ?? full, // "Jun 22"
+      full, // "Mon, Jun 22"
+      cost: d.cost,
+      requests: d.requests,
+      byModel: d.byModel,
+      isToday: i === days.length - 1,
+    };
+  });
+  return (
+    <div className="h-[200px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#26262f" vertical={false} />
+          <XAxis
+            dataKey="label"
+            tick={{ fill: '#71717a', fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            interval="preserveStartEnd"
+            minTickGap={24}
+          />
+          <YAxis
+            tickFormatter={(v) => usd(Number(v))}
+            tick={{ fill: '#71717a', fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={52}
+          />
+          <Tooltip cursor={{ fill: 'rgba(255,255,255,0.05)' }} content={<DailyTooltip />} />
+          <Bar dataKey="cost" radius={[4, 4, 0, 0]}>
+            {data.map((d) => (
+              <Cell key={d.label} fill={d.isToday ? BAR_TODAY : BAR} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/design-system/organisms/LiteLlmDailyChart/LiteLlmDailyChart.tsx
+++ b/src/components/design-system/organisms/LiteLlmDailyChart/LiteLlmDailyChart.tsx
@@ -38,7 +38,7 @@ function DailyTooltip({ active, payload }: LiteLlmDailyTooltipProps) {
         </div>
       )}
       <div className="mt-2 border-t border-white/10 pt-2 text-xs text-zinc-500">
-        {d.requests.toLocaleString()} requests
+        {d.successful.toLocaleString()} successful
       </div>
     </ChartTooltip>
   );
@@ -55,6 +55,7 @@ export function LiteLlmDailyChart({ days }: LiteLlmDailyChartProps) {
       full, // "Mon, Jun 22"
       cost: d.cost,
       requests: d.requests,
+      successful: d.successful,
       byModel: d.byModel,
       isToday: i === days.length - 1,
     };

--- a/src/components/design-system/organisms/LiteLlmDailyChart/types.ts
+++ b/src/components/design-system/organisms/LiteLlmDailyChart/types.ts
@@ -1,0 +1,24 @@
+export interface LiteLlmDay {
+  date: string;
+  cost: number;
+  requests: number;
+  byModel: Record<string, number>;
+}
+
+export interface LiteLlmDailyChartProps {
+  days: LiteLlmDay[];
+}
+
+export interface LiteLlmDailyTooltipProps {
+  active?: boolean;
+  payload?: Array<{
+    payload: {
+      full: string;
+      label: string;
+      cost: number;
+      requests: number;
+      byModel: Record<string, number>;
+      isToday: boolean;
+    };
+  }>;
+}

--- a/src/components/design-system/organisms/LiteLlmDailyChart/types.ts
+++ b/src/components/design-system/organisms/LiteLlmDailyChart/types.ts
@@ -2,6 +2,7 @@ export interface LiteLlmDay {
   date: string;
   cost: number;
   requests: number;
+  successful: number;
   byModel: Record<string, number>;
 }
 
@@ -17,6 +18,7 @@ export interface LiteLlmDailyTooltipProps {
       label: string;
       cost: number;
       requests: number;
+      successful: number;
       byModel: Record<string, number>;
       isToday: boolean;
     };

--- a/src/components/design-system/organisms/McpBreakdown/McpBreakdown.tsx
+++ b/src/components/design-system/organisms/McpBreakdown/McpBreakdown.tsx
@@ -61,7 +61,7 @@ export function McpBreakdown({ data }: McpBreakdownProps) {
       {/* Per-server table: name · calls · errors, columns aligned */}
       {data.perServer.length > 0 && (
         <div>
-          <div className="mb-1.5 flex items-center gap-2 border-b border-white/5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+          <div className="mb-1.5 flex items-center gap-2 border-b border-white/10 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
             <span className="flex-1">MCP server</span>
             <span className="w-14 text-right">calls</span>
             <span className="w-14 text-right">errors</span>

--- a/src/components/design-system/organisms/ModelBreakdown/ModelBreakdown.tsx
+++ b/src/components/design-system/organisms/ModelBreakdown/ModelBreakdown.tsx
@@ -71,7 +71,7 @@ export function ModelBreakdown({ models }: ModelBreakdownProps) {
 
       {/* Cost efficiency bars */}
       {efficiencyData.length > 0 && (
-        <div className="space-y-2 pt-3 border-t border-white/5">
+        <div className="space-y-2 pt-3 border-t border-white/10">
           <div className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-3">
             Cost per 1M effective tokens
           </div>

--- a/src/components/design-system/organisms/RetryPanel/RetryPanel.tsx
+++ b/src/components/design-system/organisms/RetryPanel/RetryPanel.tsx
@@ -30,11 +30,11 @@ export function RetryPanel({ data }: RetryPanelProps) {
 
       {/* Stats grid */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/5">
+        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/10">
           <div className="text-xs text-zinc-500">Retried edits</div>
           <div className="mt-1 text-xl font-bold tabular-nums text-amber-400">{retried}</div>
         </div>
-        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/5">
+        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/10">
           <div className="text-xs text-zinc-500">Wasted tokens</div>
           <div className="mt-1 text-xl font-bold tabular-nums text-zinc-400">
             {compact(wastedTokens)}

--- a/src/components/design-system/organisms/SessionHistoryTable/SessionHistoryTable.tsx
+++ b/src/components/design-system/organisms/SessionHistoryTable/SessionHistoryTable.tsx
@@ -50,7 +50,7 @@ function TurnBlock({ turn }: { turn: SessionTranscriptTurn }) {
             {turn.tools.map((t, i) => (
               <span
                 key={i}
-                className="rounded-full bg-ink-700 border border-white/5 px-2 py-0.5 text-zinc-400"
+                className="rounded-full bg-ink-700 border border-white/10 px-2 py-0.5 text-zinc-400"
                 title={t.brief || t.name}
               >
                 {t.name}
@@ -125,7 +125,7 @@ function SearchStrip({
 
   if (loading) {
     return (
-      <div className="mb-3 rounded-xl bg-ink-700/40 border border-white/5 px-3 py-2 text-xs text-zinc-600">
+      <div className="mb-3 rounded-xl bg-ink-700/40 border border-white/10 px-3 py-2 text-xs text-zinc-600">
         Searching transcripts…
       </div>
     );
@@ -133,23 +133,23 @@ function SearchStrip({
 
   if (!results || results.length === 0) {
     return (
-      <div className="mb-3 rounded-xl bg-ink-700/40 border border-white/5 px-3 py-2 text-xs text-zinc-600">
+      <div className="mb-3 rounded-xl bg-ink-700/40 border border-white/10 px-3 py-2 text-xs text-zinc-600">
         No transcript matches for "{query}"
       </div>
     );
   }
 
   return (
-    <div className="mb-3 rounded-xl bg-ink-700/40 border border-white/5 overflow-hidden">
-      <div className="px-3 py-2 border-b border-white/5 text-xs font-semibold text-zinc-400">
+    <div className="mb-3 rounded-xl bg-ink-700/40 border border-white/10 overflow-hidden">
+      <div className="px-3 py-2 border-b border-white/10 text-xs font-semibold text-zinc-400">
         Found in {results.length} session transcript{results.length !== 1 ? 's' : ''}
       </div>
-      <div className="divide-y divide-white/5">
+      <div className="divide-y divide-white/10">
         {results.slice(0, 8).map((r) => (
           <button
             key={r.sessionId}
             onClick={() => onJump(r.sessionId)}
-            className="w-full text-left px-3 py-2 hover:bg-white/5 transition-colors flex flex-col gap-0.5"
+            className="w-full text-left px-3 py-2 hover:bg-white/10 transition-colors flex flex-col gap-0.5"
           >
             <div className="flex items-center gap-2 text-xs">
               <span className="font-semibold text-zinc-300 truncate">{r.project || 'unknown'}</span>
@@ -264,7 +264,7 @@ export function SessionHistoryTable({
       <div className="flex-1 overflow-x-auto">
         <table className="w-full text-left text-xs border-collapse">
           <thead>
-            <tr className="border-b border-white/5 text-zinc-500 font-semibold uppercase tracking-wider">
+            <tr className="border-b border-white/10 text-zinc-500 font-semibold uppercase tracking-wider">
               <th className="py-2.5">Start Time</th>
               <th className="py-2.5">Project</th>
               <th className="py-2.5">First Prompt</th>
@@ -272,7 +272,7 @@ export function SessionHistoryTable({
               <th className="py-2.5 text-right">Tokens</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-white/5 text-zinc-300">
+          <tbody className="divide-y divide-white/10 text-zinc-300">
             {paginatedSessions.length > 0 ? (
               paginatedSessions.map((s) => {
                 const projectName = s.source === 'cowork' ? 'Cowork' : getProjectName(s.project_path);
@@ -282,7 +282,7 @@ export function SessionHistoryTable({
                   <tr
                     key={s.session_id}
                     onClick={() => openSession(s)}
-                    className="hover:bg-white/5 transition-colors cursor-pointer"
+                    className="hover:bg-white/10 transition-colors cursor-pointer"
                   >
                     <td className="py-3 font-mono text-zinc-400 text-xs">
                       {formatDate(s.start_time)}
@@ -312,7 +312,7 @@ export function SessionHistoryTable({
       </div>
 
       {/* Pagination controls */}
-      <div className="mt-4 flex items-center justify-between border-t border-white/5 pt-3 flex-none text-xs text-zinc-500">
+      <div className="mt-4 flex items-center justify-between border-t border-white/10 pt-3 flex-none text-xs text-zinc-500">
         <span>
           Showing {(currentPage - 1) * itemsPerPage + 1} to{' '}
           {Math.min(currentPage * itemsPerPage, filteredSessions.length)} of{' '}
@@ -323,7 +323,7 @@ export function SessionHistoryTable({
           <button
             onClick={() => setCurrentPage((c) => Math.max(1, c - 1))}
             disabled={currentPage === 1}
-            className="rounded-lg px-2.5 py-1 bg-ink-700/50 border border-white/5 text-zinc-300 hover:text-zinc-100 disabled:opacity-30 disabled:hover:text-zinc-300 transition-opacity"
+            className="rounded-lg px-2.5 py-1 bg-ink-700/50 border border-white/10 text-zinc-300 hover:text-zinc-100 disabled:opacity-30 disabled:hover:text-zinc-300 transition-opacity"
           >
             Prev
           </button>
@@ -333,7 +333,7 @@ export function SessionHistoryTable({
           <button
             onClick={() => setCurrentPage((c) => Math.min(totalPages, c + 1))}
             disabled={currentPage === totalPages}
-            className="rounded-lg px-2.5 py-1 bg-ink-700/50 border border-white/5 text-zinc-300 hover:text-zinc-100 disabled:opacity-30 disabled:hover:text-zinc-300 transition-opacity"
+            className="rounded-lg px-2.5 py-1 bg-ink-700/50 border border-white/10 text-zinc-300 hover:text-zinc-100 disabled:opacity-30 disabled:hover:text-zinc-300 transition-opacity"
           >
             Next
           </button>
@@ -416,7 +416,7 @@ export function SessionHistoryTable({
                     {Object.entries(modalSession.tool_counts).map(([tool, count]) => (
                       <div
                         key={tool}
-                        className="rounded-lg bg-ink-800 border border-white/5 px-2.5 py-1 flex items-center gap-1.5"
+                        className="rounded-lg bg-ink-800 border border-white/10 px-2.5 py-1 flex items-center gap-1.5"
                       >
                         <span className="font-semibold text-clay-400 font-mono">{count}</span>
                         <span className="text-zinc-300 font-sans">{tool}</span>
@@ -430,7 +430,7 @@ export function SessionHistoryTable({
             </div>
 
             {/* Transcript — collapsed by default, fetched on first expand */}
-            <div className="mt-5 border-t border-white/5 pt-4">
+            <div className="mt-5 border-t border-white/10 pt-4">
               <button
                 onClick={() => setTranscriptOpen((v) => !v)}
                 className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-zinc-500 hover:text-zinc-300 transition-colors"

--- a/src/components/design-system/organisms/SettingsView/SettingsView.tsx
+++ b/src/components/design-system/organisms/SettingsView/SettingsView.tsx
@@ -89,7 +89,7 @@ export function SettingsView({
       </section>
 
       {/* ── Spending limits ────────────────────────────────────────── */}
-      <section className="border-t border-white/5 pt-5">
+      <section className="border-t border-white/10 pt-5">
         <h4 className="mb-1 text-sm font-semibold text-zinc-300">Spending limits</h4>
         <p className="mb-3 text-xs text-zinc-500">
           For pay-as-you-go usage — enter caps in USD to see gauges on the Live tab. Stored locally in
@@ -132,7 +132,7 @@ export function SettingsView({
       </section>
 
       {/* ── AI Insights ────────────────────────────────────────────── */}
-      <section className="mt-6 border-t border-white/5 pt-5">
+      <section className="mt-6 border-t border-white/10 pt-5">
         <h4 className="mb-1 text-sm font-semibold text-zinc-300">AI Insights</h4>
         <p className="mb-3 text-xs text-zinc-500">
           Powers the AI chat and the ✨ buttons. Choose a provider, model and paste an API key. The key is
@@ -218,7 +218,7 @@ export function SettingsView({
       </section>
 
       {/* ── Telemetry ──────────────────────────────────────────────── */}
-      <section className="mt-6 border-t border-white/5 pt-5">
+      <section className="mt-6 border-t border-white/10 pt-5">
         <h4 className="mb-1 text-sm font-semibold text-zinc-300">Telemetry</h4>
         <p className="mb-3 text-xs text-zinc-500">
           Your usage logs never leave your machine. The app sends only{' '}

--- a/src/components/design-system/organisms/Sidebar/Sidebar.tsx
+++ b/src/components/design-system/organisms/Sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ const faviconUrl = '/favicon.svg';
 /** Left navigation rail: brand + the scanned dir + vertical tab nav + footer credits. */
 export function Sidebar({ tabs, activeTab, onNavigate, claudeDir, version }: SidebarProps) {
   return (
-    <aside className="flex w-60 shrink-0 flex-col border-r border-white/5 bg-ink-900/60">
+    <aside className="flex w-60 shrink-0 flex-col border-r border-white/10 bg-ink-900/60">
       <div className="px-4 pb-4 pt-5">
         <div className="flex items-center gap-2.5">
           <img src={faviconUrl} alt="" className="h-7 w-7" />
@@ -40,7 +40,7 @@ export function Sidebar({ tabs, activeTab, onNavigate, claudeDir, version }: Sid
         ))}
       </nav>
 
-      <footer className="border-t border-white/5 px-4 py-3 text-[11px] text-zinc-600">
+      <footer className="border-t border-white/10 px-4 py-3 text-[11px] text-zinc-600">
         <p>
           Built by{' '}
           <a

--- a/src/components/design-system/organisms/SubagentStatsPanel/SubagentStatsPanel.tsx
+++ b/src/components/design-system/organisms/SubagentStatsPanel/SubagentStatsPanel.tsx
@@ -39,11 +39,11 @@ export function SubagentStatsPanel({ data }: SubagentStatsPanelProps) {
 
       {/* Stats row */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/5">
+        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/10">
           <div className="text-xs text-zinc-500">Total spawns</div>
           <div className="mt-1 text-xl font-bold tabular-nums text-zinc-200">{compact(spawns)}</div>
         </div>
-        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/5">
+        <div className="rounded-xl bg-ink-800/50 p-3 ring-1 ring-white/10">
           <div className="text-xs text-zinc-500">Avg per session</div>
           <div className="mt-1 text-xl font-bold tabular-nums text-zinc-200">
             {avgPerSession.toFixed(1)}

--- a/src/components/design-system/organisms/TasksPanel/TasksPanel.tsx
+++ b/src/components/design-system/organisms/TasksPanel/TasksPanel.tsx
@@ -39,7 +39,7 @@ export function TasksPanel({ data }: TasksPanelProps) {
             </div>
             <div className="space-y-1.5">
               {tasks.items.slice(0, 12).map((t) => (
-                <div key={t.id} className="flex items-center gap-2 rounded-lg bg-ink-800/50 px-2.5 py-1.5 text-xs ring-1 ring-white/5">
+                <div key={t.id} className="flex items-center gap-2 rounded-lg bg-ink-800/50 px-2.5 py-1.5 text-xs ring-1 ring-white/10">
                   <span className={`flex-none rounded-full px-1.5 py-0.5 text-[10px] ${statusClass(t.blocked ? 'blocked' : t.status)}`}>
                     {t.blocked ? 'blocked' : t.status}
                   </span>
@@ -62,7 +62,7 @@ export function TasksPanel({ data }: TasksPanelProps) {
         {plans.items.length > 0 ? (
           <div className="space-y-1.5">
             {plans.items.slice(0, 14).map((p) => (
-              <div key={p.name} className="flex items-center gap-2 rounded-lg bg-ink-800/50 px-2.5 py-1.5 text-xs ring-1 ring-white/5">
+              <div key={p.name} className="flex items-center gap-2 rounded-lg bg-ink-800/50 px-2.5 py-1.5 text-xs ring-1 ring-white/10">
                 <span className="min-w-0 flex-1 truncate text-zinc-300" title={p.title}>{p.title}</span>
                 <span className="flex-none tabular-nums text-zinc-600">{(p.sizeBytes / 1024).toFixed(0)}kb</span>
                 <span className="flex-none tabular-nums text-zinc-600">{p.ageDays === 0 ? 'today' : `${p.ageDays}d`}</span>

--- a/src/components/design-system/organisms/UsageBarChart/UsageBarChart.tsx
+++ b/src/components/design-system/organisms/UsageBarChart/UsageBarChart.tsx
@@ -41,7 +41,7 @@ function CustomTooltip({ active, payload, label, metric = 'tokens' }: CustomTool
           ))}
         </div>
         {metric !== 'cost' && bucketCost !== undefined && (
-          <div className="mt-2 border-t border-white/5 pt-2 flex items-center justify-between text-xs">
+          <div className="mt-2 border-t border-white/10 pt-2 flex items-center justify-between text-xs">
             <span className="text-zinc-500 font-medium">Est. Cost</span>
             <span className="font-bold text-clay-400">{usd(bucketCost)}</span>
           </div>

--- a/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
+++ b/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
@@ -62,7 +62,7 @@ function GroupLabel({ children }: { children: string }) {
 
 function CountChip({ count, label, pulse }: { count: number; label: string; pulse?: boolean }) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/5 px-2.5 py-1 text-xs font-semibold tabular-nums text-zinc-300 ring-1 ring-white/10">
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-2.5 py-1 text-xs font-semibold tabular-nums text-zinc-300 ring-1 ring-white/10">
       {pulse && <span className="pulse-dot flex-none" />}
       {count} {label}
     </span>
@@ -225,7 +225,7 @@ function WorkflowTui({ run, hideHeader }: { run: WorkflowRun; hideHeader?: boole
                   {sel.total === 0 ? 'Not started yet.' : 'No agents in this phase.'}
                 </p>
               ) : (
-                <div className="flex flex-col divide-y divide-white/5">
+                <div className="flex flex-col divide-y divide-white/10">
                   {sel.agents.map((a) => (
                     <AgentTuiRow key={a.agentId} agent={a} />
                   ))}
@@ -296,19 +296,19 @@ function RecentWorkflowRow({ run }: WorkflowCardProps) {
       {run.resultStats && (
         <div className="flex flex-wrap gap-1.5">
           {Object.entries(run.resultStats).map(([k, v]) => (
-            <span key={k} className="rounded-md bg-ink-800/60 px-1.5 py-0.5 text-[10px] text-zinc-400 ring-1 ring-white/5">
+            <span key={k} className="rounded-md bg-ink-800/60 px-1.5 py-0.5 text-[10px] text-zinc-400 ring-1 ring-white/10">
               {humanize(k)}: <span className="text-zinc-300">{String(v)}</span>
             </span>
           ))}
         </div>
       )}
       {open && hasDetail && (
-        <div className="mt-1 flex flex-col gap-2 border-t border-white/5 pt-2">
+        <div className="mt-1 flex flex-col gap-2 border-t border-white/10 pt-2">
           {run.agents.length > 0 && <WorkflowTui run={run} hideHeader />}
           {run.logsTail && run.logsTail.length > 0 && (
             <div className="flex flex-col gap-1">
               <GroupLabel>Log</GroupLabel>
-              <div className="rounded-lg bg-ink-900/60 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-zinc-500 ring-1 ring-white/5">
+              <div className="rounded-lg bg-ink-900/60 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-zinc-500 ring-1 ring-white/10">
                 {run.logsTail.map((l, i) => (
                   <div key={i} className="truncate" title={l}>{l}</div>
                 ))}

--- a/src/components/design-system/organisms/YieldPanel/YieldPanel.tsx
+++ b/src/components/design-system/organisms/YieldPanel/YieldPanel.tsx
@@ -32,7 +32,7 @@ export function YieldPanel({ data }: YieldPanelProps) {
           <div className="mt-1 text-2xl font-bold tabular-nums text-emerald-400">{committed}</div>
           <div className="text-xs text-zinc-500">{compact(tokensCommitted)} tokens</div>
         </div>
-        <div className="rounded-xl bg-zinc-800/40 p-3 ring-1 ring-white/5">
+        <div className="rounded-xl bg-zinc-800/40 p-3 ring-1 ring-white/10">
           <div className="text-xs text-zinc-500">Uncommitted sessions</div>
           <div className="mt-1 text-2xl font-bold tabular-nums text-zinc-400">{uncommitted}</div>
           <div className="text-xs text-zinc-500">{compact(tokensUncommitted)} tokens</div>

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -34,6 +34,12 @@ export function usePolling<T>(url: string, intervalMs = 5000): State<T> & { last
 
   useEffect(() => {
     alive.current = true;
+    // An empty URL means "disabled" (e.g. a feature-gated poll): make no request,
+    // settle to an idle/empty state, and skip the interval entirely.
+    if (!url) {
+      setState({ data: null, computedAt: null, claudeDir: null, error: null, loading: false });
+      return;
+    }
     // On URL change (source/range filter switch): if we already have a cached
     // response for this exact URL, show it immediately (no skeleton) and revalidate
     // in the background. Otherwise clear to a skeleton until the first response lands.

--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,7 @@ body {
 
 @layer components {
   .card {
-    @apply rounded-2xl bg-ink-800/80 border border-white/5 shadow-xl shadow-black/30 backdrop-blur;
+    @apply rounded-2xl bg-ink-800/90 border border-white/10 shadow-xl shadow-black/30 backdrop-blur;
   }
   .pulse-dot {
     @apply inline-block h-2 w-2 rounded-full bg-emerald-400;
@@ -26,7 +26,7 @@ body {
     animation: pulse 2s infinite;
   }
   .skeleton {
-    @apply relative overflow-hidden bg-white/5;
+    @apply relative overflow-hidden bg-white/10;
   }
   .skeleton::after {
     content: '';
@@ -101,11 +101,11 @@ body {
   height: 6px;
 }
 ::-webkit-scrollbar-track {
-  background: #0c0c0f; /* bg-ink-900 */
+  background: #0a0a0d; /* bg-ink-900 */
   border-radius: 8px;
 }
 ::-webkit-scrollbar-thumb {
-  background: #26262f; /* bg-ink-600 */
+  background: #353541; /* bg-ink-600 */
   border-radius: 8px;
 }
 ::-webkit-scrollbar-thumb:hover {

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,17 @@ export interface Envelope<T> {
   claudeDir: string;
 }
 
+/** Actual billed cost pulled from a LiteLLM gateway (mirrors server LiteLlmSpend). */
+export interface LiteLlmSpend {
+  monthLabel: string;
+  monthToDate: number;
+  monthRequests: number;
+  prevMonthLabel: string;
+  prevMonthToDate: number;
+  daily: { date: string; cost: number; requests: number; byModel: Record<string, number> }[];
+}
+export type LiteLlmSpendData = LiteLlmSpend | { error: string };
+
 export interface ClaudeConfig {
   effortLevel?: string;
   model?: string;
@@ -120,6 +131,7 @@ export interface ClaudeConfig {
   subscriptionType?: string | null;
   rateLimitTier?: string | null;
   authMode?: 'api' | 'subscription';
+  litellm?: { available: boolean; gatewayHost: string };
   enabledPlugins?: Record<string, boolean>;
   extraKnownMarketplaces?: Record<string, unknown>;
   permissions?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,7 @@ export interface LiteLlmSpend {
   prevMonthLabel: string;
   prevMonthToDate: number;
   lifetime: { user: number; key: number };
-  daily: { date: string; cost: number; requests: number; byModel: Record<string, number> }[];
+  daily: { date: string; cost: number; requests: number; successful: number; byModel: Record<string, number> }[];
 }
 export type LiteLlmSpendData = LiteLlmSpend | { error: string };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,8 +114,12 @@ export interface LiteLlmSpend {
   monthLabel: string;
   monthToDate: number;
   monthRequests: number;
+  monthSuccessful: number;
+  monthFailed: number;
+  monthTokens: { prompt: number; completion: number; cacheRead: number; cacheCreate: number };
   prevMonthLabel: string;
   prevMonthToDate: number;
+  lifetime: { user: number; key: number };
   daily: { date: string; cost: number; requests: number; byModel: Record<string, number> }[];
 }
 export type LiteLlmSpendData = LiteLlmSpend | { error: string };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,12 +5,23 @@ export default {
   theme: {
     extend: {
       colors: {
+        // Surface steps. 900 is the near-black page bg (deepened slightly); 800+
+        // are lifted so cards/panels separate clearly from the page on
+        // low-contrast screens.
         ink: {
-          900: '#0c0c0f',
-          800: '#131318',
-          700: '#1b1b22',
-          600: '#26262f',
-          500: '#34343f',
+          900: '#0a0a0d',
+          800: '#1c1c24',
+          700: '#282832',
+          600: '#353541',
+          500: '#45454f',
+        },
+        // Brighten the muted grays for readability on low-contrast displays (used
+        // almost exclusively as text). Other zinc shades fall through to
+        // Tailwind's defaults.
+        zinc: {
+          400: '#c0c0c8',
+          500: '#9a9aa3',
+          600: '#7c7c86',
         },
         clay: {
           400: '#e8a87c',


### PR DESCRIPTION
## Why

Lets the dashboard work for users who run Claude Code through a corporate **LiteLLM gateway** (custom `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`) instead of `api.anthropic.com`, and improves dark-theme contrast for low-contrast displays. Everything LiteLLM-specific is gated, so Code-only / direct-Anthropic users see the dashboard unchanged.

## What changed

### 1. AI Insights through the proxy (`server/ai.ts`)
- Honors Claude Code's own `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` (token sent as `Authorization: Bearer`, matching Claude Code's gateway convention). Falls back to `ANTHROPIC_API_KEY` (`x-api-key`) then the local OAuth token, as before.
- The non-auth error now names the model + base URL so a proxy model-name mismatch is self-diagnosing.

### 2. Actual billed cost from the gateway
- New `GET /api/usage/litellm` pulls real spend from the gateway's **self-scoped** `/user/daily/activity` (a virtual key reads its own spend — no master key needed): **month-to-date**, a **previous-month same-period** comparison, and a **per-day breakdown** over the selected window. One fetch (prev-month-start → today) is cached by date range and sliced per window.
- Detection (`detectLitellm`, a non-Anthropic base-URL host) is exposed on `/api/config`; the UI gates on it. Any gateway error (401/403/404/network) returns `wrap({error})` at HTTP 200 so the card simply hides — never breaks the page.
- **Trends tab:** the window selector (1w–4w) moved to the top and now drives *both* the estimate chart and the LiteLLM chart. The daily view is a vertical bar chart (`LiteLlmDailyChart`) with a per-model hover tooltip (day spend + per-model breakdown + request count); today's bar is highlighted.
- Optional `LITELLM_BASE_URL` / `LITELLM_API_KEY` overrides (documented in `.env.example` / `docker-compose.yml`) for gateways that need a separate spend-read key.

### 3. Dark-theme contrast pass
- Lifted the `ink` surface palette (page `#0a0a0d`; cards `#131318 → #1c1c24`) so panels separate from the page; brightened `zinc-400/500/600` (used almost entirely as text); strengthened the card surface/border.
- Mechanical sweep promoting the faintest hairlines `white/5 → white/10` across the design-system components.

## Verification
- `npx tsc -b` clean; `npm run build` succeeds.
- Backend exercised end-to-end against a mock `/user/daily/activity`: detection on/off, windowed daily series (7 vs 28 days), month-to-date + prev-month math, and graceful degradation (network/401/404 → card hidden). Also verified live against the real gateway in Docker.

## Reviewer notes
- **Out of scope:** the Live-usage / plan tabs still use Anthropic's OAuth-only endpoints (`/api/oauth/usage`, `/api/oauth/profile`), which a LiteLLM gateway doesn't implement — they remain pinned to `api.anthropic.com`.
- **No pricing change:** the existing "estimated equivalent cost" is unchanged; the gateway figure is shown alongside it as the real billed cost.
- **Docker gotcha (not in this diff):** Compose's `${VAR:-}` interpolation prefers the invoking shell over `.env`. Rebuilding from a shell that exports `ANTHROPIC_BASE_URL` (e.g. an automated/CI shell) will override the `.env` gateway — run such rebuilds with those vars unset, or rely on the `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

