### PR TITLE
feat(workflows): date-bucketed list + all-time stats strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2026-06-26
+
+### Added
+- Group recent runs by date with headers for Today, Yesterday, and earlier periods.
+- Display all-time stats in a compact 3x3 grid above the recent runs.
+- Introduce an all-time stats strip for quick summary insights.
+- Expand the recent workflows window from 7 days to 90 days and increase run cap from 20 to 200.
+- Implement an API endpoint to retrieve workflow statistics.
+- Create a function for rough single-rate cost estimates based on blended token rates.
+
+### Changed
+- Improve the live data polling mechanism for more timely updates.
+- Enhance internal functions for summarizing workflow statuses.
+
 ## [0.1.10] - 2026-06-25
 
 ### Added
@@ -127,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.11]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.11
 [0.1.10]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.10
 [0.1.9]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.9
 [0.1.8]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,7 +17,7 @@ import {
 import { getCommandUsage } from './history.ts';
 import { getWorkspaceTasks, getInventory } from './workspace.ts';
 import { getLiveSubagents } from './subagents-live.ts';
-import { getWorkflows } from './workflows.ts';
+import { getWorkflows, getWorkflowStats } from './workflows.ts';
 import { runAi, runAiStream, resolveBackend, AiUnavailableError, AiTokenRejectedError, AiCallError, type AiCreds } from './ai.ts';
 import { buildAiContext, buildChatUserMessage, CHAT_SYSTEM, buildSectionUserMessage, SECTION_SYSTEM, SUGGEST_SYSTEM, buildSuggestMessage, type ChatTurn } from './ai-context.ts';
 import { getVersionInfo, isDocker } from './version.ts';
@@ -586,6 +586,16 @@ app.get('/api/subagents/live', async (_req, res) => {
 app.get('/api/workflows', async (_req, res) => {
   try {
     const data = await getWorkflows();
+    res.json(wrap(data, Date.now()));
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// All-time aggregate over every final workflow journal on disk.
+app.get('/api/workflows/stats', async (_req, res) => {
+  try {
+    const data = await getWorkflowStats();
     res.json(wrap(data, Date.now()));
   } catch (e) {
     res.status(500).json({ error: String(e) });

--- a/server/pricing.ts
+++ b/server/pricing.ts
@@ -46,3 +46,14 @@ export function estimateCost(
     1_000_000
   );
 }
+
+/**
+ * A single blended $/Mtok rate for a model, used ONLY where the input/output split
+ * is unavailable (workflow journals store one combined "effective" token count).
+ * Approximates a typical agent mix as ~70% input-class / ~30% output tokens — a
+ * rough equivalent-API estimate, not a real bill.
+ */
+export function blendedRatePerMillion(model: string): number {
+  const p = priceFor(model);
+  return 0.7 * p.input + 0.3 * p.output;
+}

--- a/server/workflows.ts
+++ b/server/workflows.ts
@@ -20,6 +20,7 @@ import { readdir, stat, readFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { createInterface } from 'node:readline';
 import { claudeDir } from './scan.ts';
+import { blendedRatePerMillion } from './pricing.ts';
 
 // ── Public shapes (mirror src/types.ts) ──────────────────────────────────────
 
@@ -66,11 +67,27 @@ export interface WorkflowsData {
   recent: WorkflowRun[];
 }
 
+/** All-time aggregate over every final workflow journal on disk. */
+export interface WorkflowStats {
+  totalRuns: number;
+  completed: number;
+  failed: number;
+  successRate: number; // 0..1, completed / (completed + failed)
+  totalTokens: number;
+  totalAgents: number;
+  avgDurationMs: number;
+  topModel: string;
+  estCostUsd: number; // rough blended equivalent-API estimate
+  totalToolCalls: number;
+  busiestDay: { day: number; count: number } | null; // day = local-midnight ms
+}
+
 // ── Tunables ─────────────────────────────────────────────────────────────────
 
 const LIVE_WINDOW = 90_000; // run touched in last 90s → live
-const RECENT_WINDOW = 7 * 24 * 3_600_000; // completed runs surfaced for 7 days
-const MAX_RECENT = 20;
+const RECENT_WINDOW = 90 * 24 * 3_600_000; // completed runs surfaced for 90 days
+const MAX_RECENT = 200;
+const STATS_TTL = 30_000; // all-time stats move slowly; don't recompute on the 4s list poll
 const MAX_JOURNAL = 8 * 1024 * 1024; // skip absurd final journals (the `script` field is large)
 const MAX_AGENT_FILE = 50 * 1024 * 1024;
 const LIVE_AGENT_PARSE = 24; // parse at most N newest agent transcripts per live run
@@ -412,7 +429,20 @@ function extractStats(result: any): Record<string, number | string> | undefined 
   return n > 0 ? out : undefined;
 }
 
+// Final journals are write-once, so a full parse can be memoized by (path, mtime).
+// This keeps the wider 90-day / 200-run scan cheap on the 4s poll: only *new*
+// journals are re-parsed; everything else returns from cache.
+const runCache = new Map<string, { mtime: number; run: WorkflowRun | null }>();
+
 async function parseFinalJournal(j: DiscoveredJournal): Promise<WorkflowRun | null> {
+  const cached = runCache.get(j.path);
+  if (cached && cached.mtime === j.mtime) return cached.run;
+  const run = await parseFinalJournalUncached(j);
+  runCache.set(j.path, { mtime: j.mtime, run });
+  return run;
+}
+
+async function parseFinalJournalUncached(j: DiscoveredJournal): Promise<WorkflowRun | null> {
   const project = projectNameFromPath(projectPathFromFile(j.path));
   if (j.size > MAX_JOURNAL) {
     return {
@@ -517,7 +547,7 @@ async function computeWorkflows(): Promise<WorkflowsData> {
     const probe = await probeRunDir(d.dir);
     const final = journalByRunId.get(d.runId);
     const newest = Math.max(probe.dirMtime, probe.journalMtime, probe.newestAgentMtime);
-    const isLive = now - newest < LIVE_WINDOW && (!final || (await peekStatus(final)) !== 'completed');
+    const isLive = now - newest < LIVE_WINDOW && (!final || (await peekSummary(final)).status !== 'completed');
     if (isLive) {
       live.push(await buildLiveRun(d, probe));
       liveRunIds.add(d.runId);
@@ -542,22 +572,127 @@ async function computeWorkflows(): Promise<WorkflowsData> {
   return { live, recent };
 }
 
-// Cheap status peek for the liveness gate without a full parse.
-const statusCache = new Map<string, { status: string; mtime: number }>();
-async function peekStatus(j: DiscoveredJournal): Promise<string> {
-  const cached = statusCache.get(j.path);
-  if (cached && cached.mtime === j.mtime) return cached.status;
-  let status = 'unknown';
+// Scalar summary of a final journal — feeds both the liveness gate (status) and
+// the all-time stats aggregate. Memoized by (path, mtime); journals are write-once
+// so the cache is effectively permanent after first warm-up.
+interface JournalSummary {
+  status: 'completed' | 'failed' | 'unknown';
+  startedAt: number;
+  durationMs: number;
+  tokens: number;
+  toolCalls: number;
+  agentCount: number;
+  defaultModel: string;
+}
+
+const summaryCache = new Map<string, { mtime: number; summary: JournalSummary }>();
+
+async function peekSummary(j: DiscoveredJournal): Promise<JournalSummary> {
+  const cached = summaryCache.get(j.path);
+  if (cached && cached.mtime === j.mtime) return cached.summary;
+  let summary: JournalSummary = {
+    status: 'unknown',
+    startedAt: j.mtime,
+    durationMs: 0,
+    tokens: 0,
+    toolCalls: 0,
+    agentCount: 0,
+    defaultModel: 'inherit',
+  };
   try {
     if (j.size <= MAX_JOURNAL) {
       const o = JSON.parse(await readFile(j.path, 'utf8'));
-      status = typeof o.status === 'string' ? o.status : 'unknown';
+      const wp: any[] = Array.isArray(o.workflowProgress) ? o.workflowProgress : [];
+      const agentEntries = wp.filter((x) => x?.type === 'workflow_agent');
+      const lastActivity = Date.parse(o.timestamp) || j.mtime;
+      summary = {
+        status: o.status === 'completed' ? 'completed' : o.status ? 'failed' : 'unknown',
+        startedAt: num(o.startTime) || lastActivity,
+        durationMs: num(o.durationMs),
+        tokens: num(o.totalTokens) > 0 ? num(o.totalTokens) : agentEntries.reduce((s, a) => s + num(a.tokens), 0),
+        toolCalls: num(o.totalToolCalls) || agentEntries.reduce((s, a) => s + num(a.toolCalls), 0),
+        agentCount: num(o.agentCount) || agentEntries.length,
+        defaultModel: String(o.defaultModel || 'inherit'),
+      };
     }
   } catch {
     /* ignore */
   }
-  statusCache.set(j.path, { status, mtime: j.mtime });
-  return status;
+  summaryCache.set(j.path, { mtime: j.mtime, summary });
+  return summary;
+}
+
+function startOfDay(ts: number): number {
+  if (!ts) return 0;
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+async function computeWorkflowStats(): Promise<WorkflowStats> {
+  const { journals } = await discover();
+  const summaries = await Promise.all(journals.map((j) => peekSummary(j)));
+
+  let completed = 0;
+  let failed = 0;
+  let totalTokens = 0;
+  let totalAgents = 0;
+  let totalToolCalls = 0;
+  let durSum = 0;
+  let durCount = 0;
+  let estCostUsd = 0;
+  const modelFreq = new Map<string, number>();
+  const dayFreq = new Map<number, number>();
+
+  for (const s of summaries) {
+    if (s.status === 'completed') completed++;
+    else if (s.status === 'failed') failed++;
+    totalTokens += s.tokens;
+    totalAgents += s.agentCount;
+    totalToolCalls += s.toolCalls;
+    if (s.durationMs > 0) {
+      durSum += s.durationMs;
+      durCount++;
+    }
+    estCostUsd += (s.tokens / 1_000_000) * blendedRatePerMillion(s.defaultModel);
+    if (s.defaultModel && s.defaultModel !== 'inherit') {
+      modelFreq.set(s.defaultModel, (modelFreq.get(s.defaultModel) ?? 0) + 1);
+    }
+    const day = startOfDay(s.startedAt);
+    if (day > 0) dayFreq.set(day, (dayFreq.get(day) ?? 0) + 1);
+  }
+
+  let topModel = 'inherit';
+  let topFreq = 0;
+  for (const [m, f] of modelFreq) if (f > topFreq) ((topFreq = f), (topModel = m));
+
+  let busiestDay: { day: number; count: number } | null = null;
+  for (const [day, count] of dayFreq) if (!busiestDay || count > busiestDay.count) busiestDay = { day, count };
+
+  return {
+    totalRuns: journals.length,
+    completed,
+    failed,
+    successRate: completed + failed > 0 ? completed / (completed + failed) : 0,
+    totalTokens,
+    totalAgents,
+    avgDurationMs: durCount > 0 ? Math.round(durSum / durCount) : 0,
+    topModel,
+    estCostUsd,
+    totalToolCalls,
+    busiestDay,
+  };
+}
+
+let statsCached: WorkflowStats | null = null;
+let statsCachedAt = 0;
+
+export async function getWorkflowStats(): Promise<WorkflowStats> {
+  const now = Date.now();
+  if (statsCached && now - statsCachedAt < STATS_TTL) return statsCached;
+  statsCached = await computeWorkflowStats();
+  statsCachedAt = now;
+  return statsCached;
 }
 
 let cached: WorkflowsData | null = null;

--- a/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
+++ b/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import { Section } from '@/components/design-system/molecules/Section/Section';
-import { compact } from '@/lib/format';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
+import { Skeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
+import type { StatCardProps } from '@/components/design-system/atoms/StatCard/types';
+import { compact, usd, shortModel, dayLabel } from '@/lib/format';
 import { modelColor } from '@/lib/palette';
 import { elapsedSec, formatElapsed, displayModel } from '@/components/design-system/organisms/AgentActivity/utils';
-import type { WorkflowAgentInfo, WorkflowRun } from '@/types';
+import type { WorkflowAgentInfo, WorkflowRun, WorkflowStats } from '@/types';
 import type { WorkflowsViewProps, WorkflowCardProps } from './types';
-import { buildPhaseGroups, defaultActivePhaseIndex, doneAgentCount, agentMetrics } from './utils';
+import { buildPhaseGroups, defaultActivePhaseIndex, doneAgentCount, agentMetrics, groupRunsByDate } from './utils';
 import type { PhaseGroup } from './utils';
 
 /** "sourcesFetched" / "after_synthesis" → "Sources fetched" / "After synthesis". */
@@ -321,9 +324,86 @@ function RecentWorkflowRow({ run }: WorkflowCardProps) {
   );
 }
 
+/** Compact stat tile (denser than the shared StatCard atom). */
+function StatTile({ label, value, sub, accent, help }: StatCardProps) {
+  return (
+    <div className="card p-3">
+      <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-zinc-500">
+        {label}
+        {help && <InfoTip text={help} />}
+      </div>
+      <div
+        className="mt-1 text-lg font-bold leading-tight tabular-nums"
+        style={accent ? { color: accent } : undefined}
+      >
+        {value}
+      </div>
+      {sub && <div className="mt-0.5 text-[11px] text-zinc-400">{sub}</div>}
+    </div>
+  );
+}
+
+/** All-time summary tiles above the live/recent lists. */
+function StatsGrid({ stats, loading }: { stats?: WorkflowStats | null; loading: boolean }) {
+  if (loading && !stats) {
+    return (
+      <div className="grid grid-cols-3 gap-2 sm:grid-cols-3">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div key={i} className="card p-3">
+            <Skeleton className="h-2.5 w-16 rounded" />
+            <Skeleton className="mt-2 h-5 w-12 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (!stats || stats.totalRuns === 0) return null;
+
+  const dash = '—';
+  const tiles: StatCardProps[] = [
+    { label: 'Runs', value: compact(stats.totalRuns) },
+    {
+      label: 'Success rate',
+      value: stats.completed + stats.failed > 0 ? `${Math.round(stats.successRate * 100)}%` : dash,
+      accent: '#34d399',
+      sub: `${stats.completed} ok · ${stats.failed} failed`,
+    },
+    { label: 'Total tokens', value: compact(stats.totalTokens) },
+    { label: 'Agents spawned', value: compact(stats.totalAgents) },
+    {
+      label: 'Avg duration',
+      value: stats.avgDurationMs > 0 ? formatElapsed(Math.round(stats.avgDurationMs / 1000)) : dash,
+    },
+    {
+      label: 'Top model',
+      value: stats.topModel && stats.topModel !== 'inherit' ? shortModel(stats.topModel) : dash,
+    },
+    {
+      label: 'Est. cost',
+      value: stats.estCostUsd > 0 ? `~${usd(stats.estCostUsd)}` : dash,
+      accent: '#fbbf24',
+      help: 'Rough equivalent-API estimate. Workflow journals store only combined effective tokens (no input/output split), so this is a blended approximation — not a real bill.',
+    },
+    { label: 'Tool calls', value: compact(stats.totalToolCalls) },
+    {
+      label: 'Busiest day',
+      value: stats.busiestDay ? dayLabel(stats.busiestDay.day) : dash,
+      sub: stats.busiestDay ? `${stats.busiestDay.count} run${stats.busiestDay.count === 1 ? '' : 's'}` : undefined,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-3 gap-2 sm:grid-cols-3">
+      {tiles.map((t) => (
+        <StatTile key={t.label} {...t} />
+      ))}
+    </div>
+  );
+}
+
 // ── Organism ────────────────────────────────────────────────────────────────
 
-export function WorkflowsView({ data, loading }: WorkflowsViewProps) {
+export function WorkflowsView({ data, loading, stats, statsLoading }: WorkflowsViewProps) {
   const live = data?.live ?? [];
   const recent = data?.recent ?? [];
   const hasAny = live.length > 0 || recent.length > 0;
@@ -331,39 +411,43 @@ export function WorkflowsView({ data, loading }: WorkflowsViewProps) {
   return (
     <Section
       title="Workflows · live & recent"
-      help="Dynamic workflow runs (the Workflow orchestration tool). Live runs show their phases and per-phase agents, tokens and elapsed time; recent runs list completed runs with their stats. Mirrors what /workflows shows in Claude Code."
+      help="Dynamic workflow runs (the Workflow orchestration tool). Live runs show their phases and per-phase agents, tokens and elapsed time; recent runs list completed runs grouped by date. The stat strip aggregates every workflow run on disk. Mirrors what /workflows shows in Claude Code."
       right={live.length > 0 ? <CountChip count={live.length} label="running" pulse /> : undefined}
     >
-      {loading && !data ? (
-        <div className="h-10 flex items-center text-xs text-zinc-600">Loading…</div>
-      ) : hasAny ? (
-        <div className="flex flex-col gap-4">
-          {live.length > 0 && (
-            <div className="flex flex-col gap-4">
-              <GroupLabel>Live</GroupLabel>
-              {live.map((r) => (
-                <WorkflowTui key={r.runId} run={r} />
+      <div className="flex flex-col gap-4">
+        <StatsGrid stats={stats} loading={statsLoading ?? false} />
+        {loading && !data ? (
+          <div className="h-10 flex items-center text-xs text-zinc-600">Loading…</div>
+        ) : hasAny ? (
+          <div className="flex flex-col gap-4">
+            {live.length > 0 && (
+              <div className="flex flex-col gap-4">
+                <GroupLabel>Live</GroupLabel>
+                {live.map((r) => (
+                  <WorkflowTui key={r.runId} run={r} />
+                ))}
+              </div>
+            )}
+            {recent.length > 0 &&
+              groupRunsByDate(recent).map((bucket) => (
+                <div key={bucket.label} className="flex flex-col gap-2">
+                  <GroupLabel>{bucket.label}</GroupLabel>
+                  {bucket.runs.map((r) => (
+                    <RecentWorkflowRow key={r.runId} run={r} />
+                  ))}
+                </div>
               ))}
-            </div>
-          )}
-          {recent.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <GroupLabel>Recent</GroupLabel>
-              {recent.map((r) => (
-                <RecentWorkflowRow key={r.runId} run={r} />
-              ))}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="flex flex-col items-center gap-1 py-8 text-center text-sm text-zinc-600">
-          <span className="text-2xl">🔀</span>
-          <p>No workflows yet.</p>
-          <p className="text-xs text-zinc-700">
-            Run one in Claude Code (e.g. a deep-research or multi-agent workflow) and it will appear here.
-          </p>
-        </div>
-      )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-1 py-8 text-center text-sm text-zinc-600">
+            <span className="text-2xl">🔀</span>
+            <p>No workflows yet.</p>
+            <p className="text-xs text-zinc-700">
+              Run one in Claude Code (e.g. a deep-research or multi-agent workflow) and it will appear here.
+            </p>
+          </div>
+        )}
+      </div>
     </Section>
   );
 }

--- a/src/components/design-system/organisms/WorkflowsView/types.ts
+++ b/src/components/design-system/organisms/WorkflowsView/types.ts
@@ -1,8 +1,10 @@
-import type { WorkflowsData, WorkflowRun } from '@/types';
+import type { WorkflowsData, WorkflowRun, WorkflowStats } from '@/types';
 
 export interface WorkflowsViewProps {
   data: WorkflowsData | null;
   loading?: boolean;
+  stats?: WorkflowStats | null;
+  statsLoading?: boolean;
 }
 
 export interface WorkflowCardProps {

--- a/src/components/design-system/organisms/WorkflowsView/utils.ts
+++ b/src/components/design-system/organisms/WorkflowsView/utils.ts
@@ -2,6 +2,55 @@ import type { WorkflowAgentInfo, WorkflowRun } from '@/types';
 import { compact } from '@/lib/format';
 import { formatElapsed } from '@/components/design-system/organisms/AgentActivity/utils';
 
+/** A relative-date bucket of recent runs, newest-first. */
+export interface DateBucket {
+  label: string;
+  runs: WorkflowRun[];
+}
+
+/**
+ * Bucket finished runs by `startedAt` into relative date groups:
+ * Today / Yesterday / Earlier this week / Earlier this month / "<Month YYYY>".
+ * Fixed labels come first in that order; older month buckets follow newest-first.
+ * Empty buckets are dropped. Week starts Monday (local time).
+ */
+export function groupRunsByDate(runs: WorkflowRun[]): DateBucket[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const startToday = today.getTime();
+  const startYesterday = startToday - 86_400_000;
+  const mondayOffset = (today.getDay() + 6) % 7; // 0 = Monday
+  const startWeek = startToday - mondayOffset * 86_400_000;
+  const startMonth = new Date(today.getFullYear(), today.getMonth(), 1).getTime();
+
+  const labelOf = (ts: number): string => {
+    if (ts >= startToday) return 'Today';
+    if (ts >= startYesterday) return 'Yesterday';
+    if (ts >= startWeek) return 'Earlier this week';
+    if (ts >= startMonth) return 'Earlier this month';
+    return new Date(ts).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  };
+
+  const byLabel = new Map<string, WorkflowRun[]>();
+  for (const r of [...runs].sort((a, b) => b.startedAt - a.startedAt)) {
+    const label = labelOf(r.startedAt);
+    const arr = byLabel.get(label);
+    if (arr) arr.push(r);
+    else byLabel.set(label, [r]);
+  }
+
+  const buckets: DateBucket[] = [];
+  for (const l of ['Today', 'Yesterday', 'Earlier this week', 'Earlier this month']) {
+    const arr = byLabel.get(l);
+    if (arr) {
+      buckets.push({ label: l, runs: arr });
+      byLabel.delete(l);
+    }
+  }
+  for (const [label, arr] of byLabel) buckets.push({ label, runs: arr }); // month labels, newest-first
+  return buckets;
+}
+
 /** One phase plus the agents the backend has actually seen for it. */
 export interface PhaseGroup {
   title: string;

--- a/src/components/tabs/WorkflowsTab/WorkflowsTab.tsx
+++ b/src/components/tabs/WorkflowsTab/WorkflowsTab.tsx
@@ -2,6 +2,13 @@ import { WorkflowsView } from '@/components/design-system/organisms/WorkflowsVie
 import { useLiveData } from '@/hooks/useLiveData';
 
 export function WorkflowsTab() {
-  const { workflows } = useLiveData();
-  return <WorkflowsView data={workflows.data} loading={workflows.loading} />;
+  const { workflows, workflowStats } = useLiveData();
+  return (
+    <WorkflowsView
+      data={workflows.data}
+      loading={workflows.loading}
+      stats={workflowStats.data}
+      statsLoading={workflowStats.loading}
+    />
+  );
 }

--- a/src/hooks/useLiveData.tsx
+++ b/src/hooks/useLiveData.tsx
@@ -12,6 +12,7 @@ import type {
   LiveUsageData,
   LiveSubagents,
   WorkflowsData,
+  WorkflowStats,
   VersionInfo,
 } from '../types';
 
@@ -31,6 +32,7 @@ interface LiveDataCtx {
   liveUsage: PollState<LiveUsageData>;
   liveSubagents: PollState<LiveSubagents>;
   workflows: PollState<WorkflowsData>;
+  workflowStats: PollState<WorkflowStats>;
   version: PollState<VersionInfo>;
 }
 
@@ -58,6 +60,7 @@ export function LiveDataProvider({ children }: { children: ReactNode }) {
   const liveUsage = usePolling<LiveUsageData>('/api/usage/live', 15000);
   const liveSubagents = usePolling<LiveSubagents>('/api/subagents/live', 4000);
   const workflows = usePolling<WorkflowsData>('/api/workflows', 4000);
+  const workflowStats = usePolling<WorkflowStats>('/api/workflows/stats', 30000);
   const version = usePolling<VersionInfo>('/api/version', 1_800_000);
 
   const value = useMemo<LiveDataCtx>(
@@ -73,9 +76,10 @@ export function LiveDataProvider({ children }: { children: ReactNode }) {
       liveUsage,
       liveSubagents,
       workflows,
+      workflowStats,
       version,
     }),
-    [recentHours, weekDays, recent, weekly, models, litellm, liveUsage, liveSubagents, workflows, version],
+    [recentHours, weekDays, recent, weekly, models, litellm, liveUsage, liveSubagents, workflows, workflowStats, version],
   );
 
   return <LiveDataContext.Provider value={value}>{children}</LiveDataContext.Provider>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,21 @@ export interface WorkflowsData {
   recent: WorkflowRun[];
 }
 
+/** All-time aggregate over every final workflow journal on disk (`/api/workflows/stats`). */
+export interface WorkflowStats {
+  totalRuns: number;
+  completed: number;
+  failed: number;
+  successRate: number; // 0..1
+  totalTokens: number;
+  totalAgents: number;
+  avgDurationMs: number;
+  topModel: string;
+  estCostUsd: number; // rough blended equivalent-API estimate
+  totalToolCalls: number;
+  busiestDay: { day: number; count: number } | null; // day = local-midnight ms
+}
+
 // ── AI Insights ──────────────────────────────────────────────────────────────
 
 export type AiProvider = 'claude' | 'openai' | 'gemini';


### PR DESCRIPTION
## Context

The Workflows tab rendered a single flat, ungrouped **Recent** list (capped at 20 runs / 7 days) with no at-a-glance summary — only a "N running" chip. With many runs it's a long, undifferentiated scroll. This groups the list by date and adds an all-time stats strip.

## What changed

### Backend
- **`workflows.ts`** — recent window **7d → 90d**, cap **20 → 200**. Added an **mtime-keyed parse cache** for final journals (write-once → the wider scan stays cheap on the 4s poll). Generalized `peekStatus` → **`peekSummary`** (shared by the liveness gate and stats). New **`getWorkflowStats()`** aggregating *every* final journal on disk (30s TTL).
- **`pricing.ts`** — `blendedRatePerMillion()` for a rough single-rate cost estimate (journals store only combined effective tokens, no input/output split).
- **`index.ts`** — `GET /api/workflows/stats`.

### Frontend
- **`groupRunsByDate()`** — Today / Yesterday / Earlier this week / Earlier this month / month-name buckets.
- **`WorkflowsView`** — compact **3×3 StatTile grid** (9 all-time stats) above the list; recent runs grouped under date headers; Live pinned on top.
- **`useLiveData`** polls `/api/workflows/stats` (30s); types + tab wiring.

### The 9 stats
Runs · Success rate · Total tokens · Agents spawned · Avg duration · Top model · Est. cost (rough, tooltip-flagged) · Tool calls · Busiest day.

## Notes
- Est. cost is a blended equivalent-API estimate, **not a real bill** — flagged with `~` + tooltip.
- The shared `StatCard` atom was left untouched (Insights/Trends unchanged); the Workflows tiles use a denser local `StatTile`.

## Verification
- `tsc -b` clean (no test/lint suite — the bar).
- Rebuilt in Docker; `/api/workflows/stats` and `/api/workflows` return correct data; UI renders the grid + date buckets with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)