### PR TITLE
fix(agents): stop false "needs attention" on delegating/idle agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2026-06-26
+
+### Fixed
+- Stop false "needs attention" alerts on delegating/idle agents for a more accurate status display.
+- Track last tool use to prevent misreading delegation as waiting when it’s not. 
+- Ensure that only genuine user rejections trigger an error state, reducing unnecessary alerts.
+
 ## [0.1.11] - 2026-06-26
 
 ### Added
@@ -143,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.12]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.12
 [0.1.11]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.11
 [0.1.10]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.10
 [0.1.9]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2026-06-26
+
+### Fixed
+- Eliminate false "needs attention" alerts for delegating and idle agents.
+- Adjust error handling to trigger only on user rejection, reducing unnecessary alerts for failed tool uses.
+
 ## [0.1.10] - 2026-06-25
 
 ### Added
@@ -127,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.11]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.11
 [0.1.10]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.10
 [0.1.9]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.9
 [0.1.8]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/subagents-live.ts
+++ b/server/subagents-live.ts
@@ -167,6 +167,9 @@ interface MainInfo {
   hasAssistant: boolean;
   /** ts of the most recent assistant tool_use (any tool) — for waiting inference. */
   lastToolUseTs: number;
+  /** ts of the most recent NON-delegation tool_use (excludes Agent/Task spawns).
+   *  Drives pendingTool so a dangling delegation is never read as a permission prompt. */
+  lastNonDelegationToolUseTs: number;
   /** ts of the most recent tool_result resolving a tool_use. */
   lastToolResultTs: number;
   /** Whether that most recent tool_result errored or was rejected by the user. */
@@ -192,6 +195,7 @@ async function parseFileForAgentSpawns(file: string): Promise<{
     lastTs: 0,
     hasAssistant: false,
     lastToolUseTs: 0,
+    lastNonDelegationToolUseTs: 0,
     lastToolResultTs: 0,
     lastResultIsError: false,
   };
@@ -255,6 +259,10 @@ async function parseFileForAgentSpawns(file: string): Promise<{
               promptPrefix: String(block.input?.prompt ?? '').slice(0, 150),
               ts,
             });
+          } else {
+            // Non-delegation tools only: a dangling Agent/Task spawn is delegation
+            // (its result arrives when the child finishes), not a permission prompt.
+            if (ts > main.lastNonDelegationToolUseTs) main.lastNonDelegationToolUseTs = ts;
           }
         }
       }
@@ -289,7 +297,10 @@ async function parseFileForAgentSpawns(file: string): Promise<{
               isAsyncLaunch: /Async agent launched/i.test(resultText),
             });
             // Track the latest tool_result for the parent's waiting heuristic.
-            const isErr = block.is_error === true || /reject|denied|doesn't want to proceed/i.test(resultText);
+            // Only a user rejection counts toward "waiting" (red) — a benign tool
+            // failure (non-zero bash exit, empty grep, missing file) is not "needs
+            // attention"; the agent gets the error and keeps going.
+            const isErr = /reject|denied|doesn't want to proceed/i.test(resultText);
             if (ts >= main.lastToolResultTs) {
               main.lastToolResultTs = ts;
               main.lastResultIsError = isErr;
@@ -502,7 +513,7 @@ async function computeLiveSubagents(): Promise<LiveSubagentsData> {
     // within the active window, and NOT while delegating (a pending Agent spawn
     // whose subagent is still running is delegation, not waiting). Biased to
     // 'running' otherwise; see AgentTrafficStatus.
-    const pendingTool = parsed.main.lastToolUseTs > parsed.main.lastToolResultTs;
+    const pendingTool = parsed.main.lastNonDelegationToolUseTs > parsed.main.lastToolResultTs;
     const waitingLikely =
       !selfActive &&
       runningChildren === 0 &&


### PR DESCRIPTION
## Problem

In the **Agents · live activity** tab, main-session cards showed a red **NEEDS ATTENTION** badge — feeding the `N waiting` header pill, the sidebar tab badge, and desktop alerts — even when the agent had merely **delegated** to subagents or was **idle/paused**.

The `traffic: 'waiting'` state is *inferred* (the JSONL has no "awaiting permission" marker). Two flaws over-fired it:

1. **Delegation misread as a permission prompt.** Every `tool_use` — including `Agent`/`Task` spawns — advanced `lastToolUseTs`, so a dangling foreground spawn kept `pendingTool` true. When spawn→sidechain matching missed (`runningChildren` stays `0`), the parent flipped to `waiting`.
2. **Benign tool errors flipped it red.** `lastResultIsError` included `is_error === true`, so a non-zero bash exit, empty grep, or missing-file Read marked the parent "waiting" once it went quiet.

## Fix (backend-only — `server/subagents-live.ts`)

- Track `lastNonDelegationToolUseTs` (excludes `Agent`/`Task` spawns) and drive `pendingTool` from it — a dangling delegation is never read as waiting, even when child matching fails.
- Narrow the error trigger to **user rejection only**; drop `is_error`.

Genuine awaiting-permission tools and user rejections still fire red. Wire shape unchanged → no frontend edits.

| Scenario | Before | After |
|---|---|---|
| Subagents running, match fails (`runningChildren=0`) | **waiting** (bug) | running ✅ |
| Subagents just completed, parent quiet | sometimes waiting | running ✅ |
| Benign tool error then quiet (failed grep) | **waiting** (bug) | running ✅ |
| Genuine bash permission prompt | waiting | waiting ✅ |
| User rejected a tool | waiting | waiting ✅ |

## Test

- `npx tsc -b` clean.
- Rebuilt Docker; `/api/subagents/live` returns `counts.waiting: 0` with delegating orchestrators now `traffic: running` (previously `waiting`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
