### PR TITLE
fix(ui): portal tooltips + configurable first day of week

### DIFF
--- a/src/components/design-system/atoms/InfoTip/InfoTip.tsx
+++ b/src/components/design-system/atoms/InfoTip/InfoTip.tsx
@@ -1,28 +1,64 @@
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { InfoTipProps } from './types';
 
+const GUTTER = 8; // min viewport padding so the popover never runs off-screen
+const WIDTH = 256; // w-64
+
 /**
- * A small "?" badge that reveals a wrapping explanation on hover. Pure CSS
- * (group-hover), no state. `normal-case`/`font-normal` reset any uppercase/bold
+ * A small "?" badge that reveals a wrapping explanation on hover/focus. The
+ * popover is rendered in a body-level portal with fixed positioning so it
+ * escapes the card's stacking/overflow context (cards use `backdrop-blur`,
+ * which creates a stacking context that would otherwise paint it behind
+ * neighbouring cards). `normal-case`/`font-normal` reset any uppercase/bold
  * styling inherited from card headers or stat labels.
  */
 export function InfoTip({ text, align = 'left' }: InfoTipProps) {
-  const horizontal =
-    align === 'right' ? 'right-0' : align === 'center' ? 'left-1/2 -translate-x-1/2' : 'left-0';
+  const badgeRef = useRef<HTMLSpanElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+
+  function open() {
+    const rect = badgeRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const top = rect.bottom + 6;
+    // Anchor horizontally per `align`, then clamp inside the viewport gutter.
+    let left =
+      align === 'right'
+        ? rect.right - WIDTH
+        : align === 'center'
+          ? rect.left + rect.width / 2 - WIDTH / 2
+          : rect.left;
+    const maxLeft = window.innerWidth - WIDTH - GUTTER;
+    left = Math.max(GUTTER, Math.min(left, maxLeft));
+    setCoords({ top, left });
+  }
 
   return (
-    <span className="group relative inline-flex shrink-0 align-middle">
+    <span className="relative inline-flex shrink-0 align-middle">
       <span
-        className="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-white/10 text-[10px] font-bold leading-none text-zinc-400 transition-colors group-hover:bg-white/20 group-hover:text-zinc-200"
-        aria-hidden="true"
+        ref={badgeRef}
+        tabIndex={0}
+        role="button"
+        aria-label="More info"
+        className="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-white/10 text-[10px] font-bold leading-none text-zinc-400 transition-colors hover:bg-white/20 hover:text-zinc-200 focus:bg-white/20 focus:text-zinc-200 focus:outline-none"
+        onMouseEnter={open}
+        onMouseLeave={() => setCoords(null)}
+        onFocus={open}
+        onBlur={() => setCoords(null)}
       >
         ?
       </span>
-      <span
-        role="tooltip"
-        className={`pointer-events-none invisible absolute top-6 ${horizontal} z-30 w-64 rounded-lg border border-white/10 bg-ink-700 px-3 py-2 text-left text-[11px] font-normal normal-case leading-relaxed tracking-normal text-zinc-300 opacity-0 shadow-xl transition-opacity duration-150 group-hover:visible group-hover:opacity-100`}
-      >
-        {text}
-      </span>
+      {coords &&
+        createPortal(
+          <span
+            role="tooltip"
+            style={{ position: 'fixed', top: coords.top, left: coords.left, width: WIDTH }}
+            className="pointer-events-none z-[1000] rounded-lg border border-white/10 bg-ink-700 px-3 py-2 text-left text-[11px] font-normal normal-case leading-relaxed tracking-normal text-zinc-300 shadow-xl"
+          >
+            {text}
+          </span>,
+          document.body,
+        )}
     </span>
   );
 }

--- a/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
+++ b/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
 import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { formatRemainingHours, formatRemainingDays, blockBarColor } from './utils';
+import { nextWeekReset } from '@/lib/week';
 import type { PlanUsageProps } from './types';
 
 const DEFAULT_BLOCK_LIMIT = 6000000; // 6.0M effective tokens
 const DEFAULT_WEEKLY_LIMIT = 35000000; // 35M effective tokens
 
-export function PlanUsage({ block, weekly, liveUsage }: PlanUsageProps) {
+export function PlanUsage({ block, weekly, liveUsage, weekStart }: PlanUsageProps) {
   const [, forceUpdate] = useState(0);
 
   useEffect(() => {
@@ -39,7 +40,10 @@ export function PlanUsage({ block, weekly, liveUsage }: PlanUsageProps) {
 
   const liveWeeklyResetsAt = hasLive ? Date.parse(liveUsage.seven_day.resets_at) : null;
   const noActiveWeekly = hasLive && liveUsage.seven_day.resets_at == null;
-  const weeklyResetsAt = liveWeeklyResetsAt && !isNaN(liveWeeklyResetsAt) ? liveWeeklyResetsAt : (weekly?.weeklyResetsAt ?? (now + 5 * 24 * 3600_000));
+  // Live Anthropic reset wins; otherwise fall back to the user's configured week start.
+  const weeklyResetsAt = liveWeeklyResetsAt && !isNaN(liveWeeklyResetsAt)
+    ? liveWeeklyResetsAt
+    : nextWeekReset(now, weekStart);
   const weeklyRemainingMs = Math.max(0, weeklyResetsAt - now);
   const weeklyResetStr = noActiveWeekly ? 'on next msg' : formatRemainingDays(weeklyRemainingMs);
 

--- a/src/components/design-system/molecules/PlanUsage/types.ts
+++ b/src/components/design-system/molecules/PlanUsage/types.ts
@@ -1,7 +1,10 @@
 import type { ActiveBlock, WeeklyData, LiveUsageData } from '@/types';
+import type { WeekStart } from '@/lib/week';
 
 export interface PlanUsageProps {
   block: ActiveBlock | null;
   weekly: WeeklyData | null;
   liveUsage?: LiveUsageData | null;
+  /** First day of the week — drives the weekly-reset countdown fallback. */
+  weekStart: WeekStart;
 }

--- a/src/components/design-system/organisms/ActivityHeatmap/ActivityHeatmap.tsx
+++ b/src/components/design-system/organisms/ActivityHeatmap/ActivityHeatmap.tsx
@@ -3,19 +3,22 @@ import { HoverTooltip } from '@/components/design-system/molecules/HoverTooltip/
 import type { DailyActivity } from '@/types';
 import { compact } from '@/lib/format';
 import type { ActivityHeatmapProps } from './types';
-import { MONTHS, WEEKDAYS, WEEKS, color, localKey } from './utils';
+import { MONTHS, WEEKS, color, localKey, weekdayLabels } from './utils';
 
-export function ActivityHeatmap({ days }: ActivityHeatmapProps) {
+export function ActivityHeatmap({ days, weekStart }: ActivityHeatmapProps) {
   const [hoveredDate, setHoveredDate] = useState<string | null>(null);
 
   const byDate = new Map(days.map((d) => [d.date, d]));
   const max = days.reduce((m, d) => Math.max(m, d.effectiveTokens), 0);
+  const weekdays = weekdayLabels(weekStart);
 
-  // Grid of the last WEEKS*7 days, columns = weeks (Sun-start), rows = weekday.
+  // Grid of the last WEEKS*7 days, columns = weeks (week-start aligned), rows = weekday.
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const end = new Date(today);
-  end.setDate(end.getDate() + (6 - end.getDay())); // end of current week (Sat)
+  // Advance to the last day of the current week (the day before the next week start).
+  const dow = weekStart === 'sunday' ? end.getDay() : (end.getDay() + 6) % 7;
+  end.setDate(end.getDate() + (6 - dow));
   const totalDays = WEEKS * 7;
 
   const cells: DailyActivity[] = [];
@@ -59,7 +62,7 @@ export function ActivityHeatmap({ days }: ActivityHeatmapProps) {
 
           {/* Rows 1-7: Weekdays */}
           {Array.from({ length: 7 }).map((_, rowIndex) => {
-            const weekdayLabel = WEEKDAYS[rowIndex];
+            const weekdayLabel = weekdays[rowIndex];
             return (
               <Fragment key={rowIndex}>
                 <div className="text-[10px] font-bold text-zinc-500 pr-2 flex items-center justify-end h-full min-w-[28px] select-none">

--- a/src/components/design-system/organisms/ActivityHeatmap/types.ts
+++ b/src/components/design-system/organisms/ActivityHeatmap/types.ts
@@ -1,5 +1,8 @@
 import type { DailyActivity } from '@/types';
+import type { WeekStart } from '@/lib/week';
 
 export interface ActivityHeatmapProps {
   days: DailyActivity[];
+  /** First day of the week — sets the row order and column alignment. */
+  weekStart: WeekStart;
 }

--- a/src/components/design-system/organisms/ActivityHeatmap/utils.ts
+++ b/src/components/design-system/organisms/ActivityHeatmap/utils.ts
@@ -1,6 +1,19 @@
+import type { WeekStart } from '@/lib/week';
+
 export const WEEKS = 18; // ~4 months
 export const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-export const WEEKDAYS = ['', 'Mon', '', 'Wed', '', 'Fri', '']; // rows Sun..Sat, label odd rows
+
+const SHORT_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const LABELED_DOW = new Set([1, 3, 5]); // label Mon/Wed/Fri rows, blank the rest
+
+/** Row labels (top→bottom) for the heatmap, sparse, honoring the week start. */
+export function weekdayLabels(weekStart: WeekStart): string[] {
+  const startDow = weekStart === 'sunday' ? 0 : 1;
+  return Array.from({ length: 7 }, (_, i) => {
+    const dow = (startDow + i) % 7;
+    return LABELED_DOW.has(dow) ? SHORT_DAYS[dow] : '';
+  });
+}
 
 export function localKey(d: Date): string {
   const y = d.getFullYear();

--- a/src/components/design-system/organisms/SettingsView/SettingsView.tsx
+++ b/src/components/design-system/organisms/SettingsView/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { ToggleGroup } from '@/components/design-system/atoms/ToggleGroup/ToggleGroup';
 import { PROVIDER_LABELS, PROVIDER_MODELS } from '@/hooks/useAiConfig';
 import { useSettingsForm } from '@/hooks/useSettingsForm';
+import { localeDefaultWeekStart } from '@/lib/week';
 import type { Settings } from '@/hooks/useSettings';
 import type { AiProvider } from '@/types';
 import type { SettingsViewProps } from './types';
@@ -35,6 +36,14 @@ export function SettingsView({
     { value: 'notification', label: 'Notification' },
     { value: 'sound', label: 'Notification + sound' },
   ];
+
+  const weekStartOptions: { value: Settings['weekStartDay']; label: string }[] = [
+    { value: 'auto', label: 'Auto' },
+    { value: 'sunday', label: 'Sunday' },
+    { value: 'monday', label: 'Monday' },
+  ];
+  const localeWeekStart = localeDefaultWeekStart();
+  const localeWeekStartLabel = localeWeekStart === 'sunday' ? 'Sunday' : 'Monday';
 
   const inputCls = 'w-full bg-transparent px-2 py-2 text-sm text-zinc-200 outline-none';
   const wrapCls =
@@ -79,6 +88,26 @@ export function SettingsView({
           onChange={(agentAlert) => onChangeSettings({ ...settings, agentAlert })}
           grow
         />
+      </section>
+
+      {/* ── Week start ─────────────────────────────────────────────── */}
+      <section className="mt-6 border-t border-white/10 pt-5">
+        <h4 className="mb-1 text-sm font-semibold text-zinc-300">Week start</h4>
+        <p className="mb-3 text-xs text-zinc-500">
+          First day of the week for the weekly spending window and reset countdown (and the
+          activity heatmap). Auto follows your browser locale.
+        </p>
+        <ToggleGroup<Settings['weekStartDay']>
+          options={weekStartOptions}
+          value={settings.weekStartDay}
+          onChange={(weekStartDay) => onChangeSettings({ ...settings, weekStartDay })}
+          grow
+        />
+        {settings.weekStartDay === 'auto' && (
+          <p className="mt-2 text-xs text-zinc-500">
+            Locale default: <span className="font-medium text-zinc-300">{localeWeekStartLabel}</span>
+          </p>
+        )}
       </section>
 
       {/* ── Spending limits ────────────────────────────────────────── */}

--- a/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
+++ b/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import type { StatCardProps } from '@/components/design-system/atoms/StatCard/types';
 import { compact, usd, shortModel, dayLabel } from '@/lib/format';
 import { modelColor } from '@/lib/palette';
+import { useConfigMode } from '@/hooks/useConfigMode';
 import { elapsedSec, formatElapsed, displayModel } from '@/components/design-system/organisms/AgentActivity/utils';
 import type { WorkflowAgentInfo, WorkflowRun, WorkflowStats } from '@/types';
 import type { WorkflowsViewProps, WorkflowCardProps } from './types';
@@ -404,6 +405,7 @@ function StatsGrid({ stats, loading }: { stats?: WorkflowStats | null; loading: 
 // ── Organism ────────────────────────────────────────────────────────────────
 
 export function WorkflowsView({ data, loading, stats, statsLoading }: WorkflowsViewProps) {
+  const { weekStart } = useConfigMode();
   const live = data?.live ?? [];
   const recent = data?.recent ?? [];
   const hasAny = live.length > 0 || recent.length > 0;
@@ -429,7 +431,7 @@ export function WorkflowsView({ data, loading, stats, statsLoading }: WorkflowsV
               </div>
             )}
             {recent.length > 0 &&
-              groupRunsByDate(recent).map((bucket) => (
+              groupRunsByDate(recent, weekStart).map((bucket) => (
                 <div key={bucket.label} className="flex flex-col gap-2">
                   <GroupLabel>{bucket.label}</GroupLabel>
                   {bucket.runs.map((r) => (

--- a/src/components/design-system/organisms/WorkflowsView/utils.ts
+++ b/src/components/design-system/organisms/WorkflowsView/utils.ts
@@ -1,4 +1,5 @@
 import type { WorkflowAgentInfo, WorkflowRun } from '@/types';
+import type { WeekStart } from '@/lib/week';
 import { compact } from '@/lib/format';
 import { formatElapsed } from '@/components/design-system/organisms/AgentActivity/utils';
 
@@ -12,15 +13,15 @@ export interface DateBucket {
  * Bucket finished runs by `startedAt` into relative date groups:
  * Today / Yesterday / Earlier this week / Earlier this month / "<Month YYYY>".
  * Fixed labels come first in that order; older month buckets follow newest-first.
- * Empty buckets are dropped. Week starts Monday (local time).
+ * Empty buckets are dropped. Week start follows the user's preference (local time).
  */
-export function groupRunsByDate(runs: WorkflowRun[]): DateBucket[] {
+export function groupRunsByDate(runs: WorkflowRun[], weekStart: WeekStart): DateBucket[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const startToday = today.getTime();
   const startYesterday = startToday - 86_400_000;
-  const mondayOffset = (today.getDay() + 6) % 7; // 0 = Monday
-  const startWeek = startToday - mondayOffset * 86_400_000;
+  const weekOffset = weekStart === 'sunday' ? today.getDay() : (today.getDay() + 6) % 7;
+  const startWeek = startToday - weekOffset * 86_400_000;
   const startMonth = new Date(today.getFullYear(), today.getMonth(), 1).getTime();
 
   const labelOf = (ts: number): string => {

--- a/src/components/tabs/LiveTab/LiveTab.tsx
+++ b/src/components/tabs/LiveTab/LiveTab.tsx
@@ -5,6 +5,7 @@ import { PlanUsage } from '@/components/design-system/molecules/PlanUsage/PlanUs
 import { SpendingLimits } from '@/components/design-system/molecules/SpendingLimits/SpendingLimits';
 import { GaugeSkeleton, ChartSkeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import { hourLabel } from '@/lib/format';
+import { sumCostThisWeek } from '@/lib/week';
 import { useLiveData } from '@/hooks/useLiveData';
 import { useConfigMode } from '@/hooks/useConfigMode';
 import { useCostMetrics } from '@/hooks/useCostMetrics';
@@ -13,7 +14,7 @@ import type { LiveTabProps } from './types';
 
 export function LiveTab({ limits }: LiveTabProps) {
   const { recent, weekly, liveUsage, recentHours, setRecentHours } = useLiveData();
-  const { configData, isApi } = useConfigMode();
+  const { configData, isApi, weekStart } = useConfigMode();
   const { costPerDay } = useCostMetrics();
   const { litellmActual } = useLiteLlmActual();
 
@@ -71,7 +72,7 @@ export function LiveTab({ limits }: LiveTabProps) {
 
       {/* Subscription rate-limit bars — only meaningful with a plan. */}
       {configData && !isApi && (
-        <PlanUsage block={block} weekly={weekly.data} liveUsage={liveUsage.data} />
+        <PlanUsage block={block} weekly={weekly.data} liveUsage={liveUsage.data} weekStart={weekStart} />
       )}
 
       {/* Spend vs caps — always shown in API mode (the cost IS the bill);
@@ -80,7 +81,7 @@ export function LiveTab({ limits }: LiveTabProps) {
         <SpendingLimits
           limits={limits}
           costPerDay={costPerDay}
-          weekCost={weekly.data?.totals.cost}
+          weekCost={sumCostThisWeek(weekly.data?.buckets, weekStart, Date.now())}
           alwaysShow={isApi}
           actual={litellmActual ?? undefined}
         />

--- a/src/components/tabs/TrendsTab/TrendsTab.tsx
+++ b/src/components/tabs/TrendsTab/TrendsTab.tsx
@@ -21,7 +21,7 @@ import type { ActivityData, HeatmapData } from '@/types';
 
 export function TrendsTab() {
   const { coworkAvailable, source, withSrc } = useSource();
-  const { litellmAvailable, litellmHost } = useConfigMode();
+  const { litellmAvailable, litellmHost, weekStart } = useConfigMode();
   const { weekly, models, weekDays, setWeekDays } = useLiveData();
   const { costPerDay, daysLeftInMonth, projectedMonthCost, weeklyEffective, prevWeeklyEffective } =
     useCostMetrics();
@@ -152,7 +152,7 @@ export function TrendsTab() {
         help="GitHub-style calendar: one square per day, darker = more effective tokens used. Shows your day-to-day usage streaks over the last ~18 weeks."
       >
         {activity.data ? (
-          <ActivityHeatmap days={activity.data.dailyActivity} />
+          <ActivityHeatmap days={activity.data.dailyActivity} weekStart={weekStart} />
         ) : activity.loading ? (
           <HeatmapSkeleton />
         ) : null}

--- a/src/hooks/useConfigMode.tsx
+++ b/src/hooks/useConfigMode.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { usePolling } from './usePolling';
 import { useSettings } from './useSettings';
 import type { Settings } from './useSettings';
+import { localeDefaultWeekStart } from '../lib/week';
+import type { WeekStart } from '../lib/week';
 import type { ClaudeConfig } from '../types';
 
 type AuthMode = 'api' | 'subscription';
@@ -17,6 +19,8 @@ interface ConfigModeCtx {
   isApi: boolean;
   litellmAvailable: boolean;
   litellmHost: string;
+  /** First day of the week, resolved from settings ('auto' → browser locale). */
+  weekStart: WeekStart;
   settings: Settings;
   setSettings: (s: Settings) => void;
 }
@@ -43,6 +47,7 @@ export function ConfigModeProvider({ children }: { children: ReactNode }) {
       isApi: effectiveMode === 'api',
       litellmAvailable: !!config.data?.litellm?.available,
       litellmHost: config.data?.litellm?.gatewayHost ?? '',
+      weekStart: settings.weekStartDay === 'auto' ? localeDefaultWeekStart() : settings.weekStartDay,
       settings,
       setSettings,
     };

--- a/src/hooks/useLiteLlmActual.ts
+++ b/src/hooks/useLiteLlmActual.ts
@@ -1,5 +1,6 @@
 import { useLiveData } from './useLiveData';
 import { useConfigMode } from './useConfigMode';
+import { localYmd, startOfWeek } from '../lib/week';
 import type { LiteLlmSpend } from '../types';
 
 /** Real billed cost slices for the Live-tab spend widgets / daily-cap ring. */
@@ -20,18 +21,19 @@ export interface LiteLlmActualResult {
  * Actual billed spend from the LiteLLM gateway. Both values are null when no
  * gateway is configured or the report errored, so callers can hide the cards and
  * the dashboard degrades gracefully. Today = the most recent daily entry;
- * week = the last 7 of the daily series.
+ * week = the current calendar week (per the user's first-day-of-week preference).
  */
 export function useLiteLlmActual(): LiteLlmActualResult {
   const { litellm } = useLiveData();
-  const { litellmAvailable, litellmHost } = useConfigMode();
+  const { litellmAvailable, litellmHost, weekStart } = useConfigMode();
 
   const litellmSpend = litellm.data && !('error' in litellm.data) ? litellm.data : null;
+  const weekFromYmd = localYmd(startOfWeek(Date.now(), weekStart));
   const litellmActual =
     litellmAvailable && litellmSpend
       ? {
           today: litellmSpend.daily[litellmSpend.daily.length - 1]?.cost ?? 0,
-          week: litellmSpend.daily.slice(-7).reduce((s, d) => s + d.cost, 0),
+          week: litellmSpend.daily.reduce((s, d) => (d.date >= weekFromYmd ? s + d.cost : s), 0),
           month: litellmSpend.monthToDate,
           note: litellmHost ? `actual · via ${litellmHost}` : 'actual billed',
         }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -8,11 +8,18 @@ export interface Settings {
   // How to alert when an agent turns red (waiting for confirmation/attention):
   // visual badge only, + browser notification, or + an audible chime.
   agentAlert: 'visual' | 'notification' | 'sound';
+  // First day of the week for weekly windows/reset. 'auto' resolves from the
+  // browser locale (see useConfigMode → weekStart).
+  weekStartDay: 'auto' | 'sunday' | 'monday';
 }
 
 const KEY = 'claude-dashboard-settings-v1';
 
-const DEFAULTS: Settings = { modeOverride: 'auto', agentAlert: 'notification' };
+const DEFAULTS: Settings = {
+  modeOverride: 'auto',
+  agentAlert: 'notification',
+  weekStartDay: 'auto',
+};
 
 function load(): Settings {
   try {

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -1,0 +1,63 @@
+/** First-day-of-week preference, resolved to a concrete day (never 'auto'). */
+export type WeekStart = 'sunday' | 'monday';
+
+/**
+ * Best-effort first day of the week from the browser locale via `Intl.Locale`
+ * week info (`firstDay`: 1=Mon … 7=Sun). Falls back to Monday when the API is
+ * unavailable, which preserves the dashboard's previous fixed behaviour.
+ */
+export function localeDefaultWeekStart(): WeekStart {
+  try {
+    const lang = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+    // `weekInfo` (property) and `getWeekInfo()` (method) both ship across engines.
+    const loc = new Intl.Locale(lang) as Intl.Locale & {
+      weekInfo?: { firstDay: number };
+      getWeekInfo?: () => { firstDay: number };
+    };
+    const info = typeof loc.getWeekInfo === 'function' ? loc.getWeekInfo() : loc.weekInfo;
+    return info?.firstDay === 7 ? 'sunday' : 'monday';
+  } catch {
+    return 'monday';
+  }
+}
+
+/** Day-of-week index (0=Sun, 1=Mon) the week begins on. */
+function startDow(ws: WeekStart): number {
+  return ws === 'sunday' ? 0 : 1;
+}
+
+/** Local-midnight timestamp of the current week's first day. */
+export function startOfWeek(now: number, ws: WeekStart): number {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  const offset = (d.getDay() - startDow(ws) + 7) % 7;
+  d.setDate(d.getDate() - offset);
+  return d.getTime();
+}
+
+/** Local-midnight timestamp of the next week's first day (reset countdown). */
+export function nextWeekReset(now: number, ws: WeekStart): number {
+  const d = new Date(startOfWeek(now, ws));
+  d.setDate(d.getDate() + 7);
+  return d.getTime();
+}
+
+/** Local YYYY-MM-DD key for a timestamp (matches the gateway's daily date keys). */
+export function localYmd(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Sum daily-bucket cost for buckets whose start falls in the current week. */
+export function sumCostThisWeek(
+  buckets: { start: number; cost: number }[] | undefined,
+  ws: WeekStart,
+  now: number,
+): number {
+  if (!buckets) return 0;
+  const from = startOfWeek(now, ws);
+  return buckets.reduce((s, b) => (b.start >= from ? s + b.cost : s), 0);
+}


### PR DESCRIPTION
## What & why

Three reported issues, all UI/client-side:

### 1. Help tooltips render behind adjacent cards
The `InfoTip` "?" popover already used `z-30`, but every `.card` uses `backdrop-blur`, which creates its own **stacking context** — so a tooltip overflowing one card was painted *beneath* the next card, and z-index couldn't cross the boundary. Fix: render the popover in a **body-level portal** (`createPortal`) with `position: fixed`, positioned from the badge's bounding rect and clamped to an 8px viewport gutter. It now sits above everything regardless of card overflow/stacking. Public API (`text`, `align`) is unchanged, so all call sites are untouched; also added keyboard focus support.

### 2. "This week" spend bars never reset
Both the gateway-actual value (`daily.slice(-7)`) and the estimate (backend rolling `totals.cost`) were **rolling 7-day windows**, not calendar weeks — so at the start of a new week they still showed the trailing 7 days at 100%. They now sum the **current calendar week**, computed on the frontend from the per-day data already available.

### 3. Configurable first day of week
New **Week start** setting (`auto` / `sunday` / `monday`, default `auto` = browser locale via `Intl.Locale` week info), persisted in `localStorage` alongside existing settings and resolved to a concrete `weekStart` on `useConfigMode`. Applied everywhere weeks appear:
- "This week" spend bars (gateway-actual + estimate)
- weekly-reset countdown fallback (`nextWeekReset(weekStart)`) — live Anthropic `resets_at` still wins for real subscribers
- Activity heatmap row order / column alignment
- Workflows "earlier this week" grouping

## Notes for reviewers
- **No backend changes** — all week math lives in the new `src/lib/week.ts`; no query-param threading. Backend `nextMondayReset` is left as a now-unused legacy field.
- Migration is automatic: the `{...DEFAULTS, ...loaded}` spread in `useSettings` backfills `weekStartDay: 'auto'` for existing stored settings.
- `npx tsc -b` clean; `npm run build` passes.

## Test plan
- Hover a "?" badge near a card edge (e.g. EFFECTIVE TOKENS) → tooltip is no longer clipped.
- Settings → Week start: toggle persists across reload; `auto` shows the locale default.
- With Sunday selected on a Sunday: "This week" bars drop to that day's spend and "resets in" counts to next Sunday; switching to Monday shifts the window/countdown.
- Activity heatmap top row and Workflows "Earlier this week" boundary follow the chosen day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)