### PR TITLE
feat: LiteLLM-inspired tagging, budgets, forecasting & spend reports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ export default function App() {
   const { recent, weekly, version } = useLiveData();
   const [limits, setLimits] = useLimits();
   const sidebarTabs = useSidebarTabs(TABS);
-  useDashboardNotifications(activeTab);
+  useDashboardNotifications(activeTab, limits);
 
   const error = recent.error || weekly.error;
   const empty =

--- a/src/components/design-system/atoms/InfoTip/InfoTip.tsx
+++ b/src/components/design-system/atoms/InfoTip/InfoTip.tsx
@@ -1,28 +1,64 @@
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { InfoTipProps } from './types';
 
+const GUTTER = 8; // min viewport padding so the popover never runs off-screen
+const WIDTH = 256; // w-64
+
 /**
- * A small "?" badge that reveals a wrapping explanation on hover. Pure CSS
- * (group-hover), no state. `normal-case`/`font-normal` reset any uppercase/bold
+ * A small "?" badge that reveals a wrapping explanation on hover/focus. The
+ * popover is rendered in a body-level portal with fixed positioning so it
+ * escapes the card's stacking/overflow context (cards use `backdrop-blur`,
+ * which creates a stacking context that would otherwise paint it behind
+ * neighbouring cards). `normal-case`/`font-normal` reset any uppercase/bold
  * styling inherited from card headers or stat labels.
  */
 export function InfoTip({ text, align = 'left' }: InfoTipProps) {
-  const horizontal =
-    align === 'right' ? 'right-0' : align === 'center' ? 'left-1/2 -translate-x-1/2' : 'left-0';
+  const badgeRef = useRef<HTMLSpanElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+
+  function open() {
+    const rect = badgeRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const top = rect.bottom + 6;
+    // Anchor horizontally per `align`, then clamp inside the viewport gutter.
+    let left =
+      align === 'right'
+        ? rect.right - WIDTH
+        : align === 'center'
+          ? rect.left + rect.width / 2 - WIDTH / 2
+          : rect.left;
+    const maxLeft = window.innerWidth - WIDTH - GUTTER;
+    left = Math.max(GUTTER, Math.min(left, maxLeft));
+    setCoords({ top, left });
+  }
 
   return (
-    <span className="group relative inline-flex shrink-0 align-middle">
+    <span className="relative inline-flex shrink-0 align-middle">
       <span
-        className="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-white/10 text-[10px] font-bold leading-none text-zinc-400 transition-colors group-hover:bg-white/20 group-hover:text-zinc-200"
-        aria-hidden="true"
+        ref={badgeRef}
+        tabIndex={0}
+        role="button"
+        aria-label="More info"
+        className="flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-white/10 text-[10px] font-bold leading-none text-zinc-400 transition-colors hover:bg-white/20 hover:text-zinc-200 focus:bg-white/20 focus:text-zinc-200 focus:outline-none"
+        onMouseEnter={open}
+        onMouseLeave={() => setCoords(null)}
+        onFocus={open}
+        onBlur={() => setCoords(null)}
       >
         ?
       </span>
-      <span
-        role="tooltip"
-        className={`pointer-events-none invisible absolute top-6 ${horizontal} z-30 w-64 rounded-lg border border-white/10 bg-ink-700 px-3 py-2 text-left text-[11px] font-normal normal-case leading-relaxed tracking-normal text-zinc-300 opacity-0 shadow-xl transition-opacity duration-150 group-hover:visible group-hover:opacity-100`}
-      >
-        {text}
-      </span>
+      {coords &&
+        createPortal(
+          <span
+            role="tooltip"
+            style={{ position: 'fixed', top: coords.top, left: coords.left, width: WIDTH }}
+            className="pointer-events-none z-[1000] rounded-lg border border-white/10 bg-ink-700 px-3 py-2 text-left text-[11px] font-normal normal-case leading-relaxed tracking-normal text-zinc-300 shadow-xl"
+          >
+            {text}
+          </span>,
+          document.body,
+        )}
     </span>
   );
 }

--- a/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
+++ b/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
@@ -2,13 +2,16 @@ import { useEffect, useState } from 'react';
 import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
 import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { formatRemainingHours, formatRemainingDays, blockBarColor } from './utils';
-import { nextWeekReset } from '@/lib/week';
+import { nextWeekReset, startOfWeek } from '@/lib/week';
+import { buildWeeklyForecast } from '@/lib/forecast';
 import type { PlanUsageProps } from './types';
+
+const WEEK_MS = 7 * 24 * 3600_000;
 
 const DEFAULT_BLOCK_LIMIT = 6000000; // 6.0M effective tokens
 const DEFAULT_WEEKLY_LIMIT = 35000000; // 35M effective tokens
 
-export function PlanUsage({ block, weekly, liveUsage, weekStart }: PlanUsageProps) {
+export function PlanUsage({ block, weekly, liveUsage, weekStart, tier }: PlanUsageProps) {
   const [, forceUpdate] = useState(0);
 
   useEffect(() => {
@@ -34,9 +37,10 @@ export function PlanUsage({ block, weekly, liveUsage, weekStart }: PlanUsageProp
 
   // Weekly calculations
   const weeklyLimit = DEFAULT_WEEKLY_LIMIT;
-  const weeklyPct = hasLive
-    ? Math.round(liveUsage.seven_day.utilization)
-    : Math.min(100, Math.round(((weekly?.totals.effectiveTokens ?? 0) / weeklyLimit) * 100));
+  const weeklyPctRaw = hasLive
+    ? liveUsage.seven_day.utilization
+    : Math.min(100, ((weekly?.totals.effectiveTokens ?? 0) / weeklyLimit) * 100);
+  const weeklyPct = Math.round(weeklyPctRaw);
 
   const liveWeeklyResetsAt = hasLive ? Date.parse(liveUsage.seven_day.resets_at) : null;
   const noActiveWeekly = hasLive && liveUsage.seven_day.resets_at == null;
@@ -47,22 +51,41 @@ export function PlanUsage({ block, weekly, liveUsage, weekStart }: PlanUsageProp
   const weeklyRemainingMs = Math.max(0, weeklyResetsAt - now);
   const weeklyResetStr = noActiveWeekly ? 'on next msg' : formatRemainingDays(weeklyRemainingMs);
 
+  // Burn-rate forecast for the weekly window (LiteLLM-inspired): where usage lands
+  // by reset at the current pace. Window start is Anthropic's (resets−7d) when live,
+  // else the user's calendar week. Suppressed when there's no active weekly window.
+  const weeklyWindowStart = liveWeeklyResetsAt && !isNaN(liveWeeklyResetsAt)
+    ? liveWeeklyResetsAt - WEEK_MS
+    : startOfWeek(now, weekStart);
+  const weeklyForecast = noActiveWeekly
+    ? null
+    : buildWeeklyForecast({ pct: weeklyPctRaw, windowStart: weeklyWindowStart, resetsAt: weeklyResetsAt, now });
+
   // Model-specific weekly limits — only present on some plans (e.g. Max exposes a Sonnet cap).
   const modelLimits = hasLive
     ? ([
         { label: 'Weekly · Sonnet', info: liveUsage.seven_day_sonnet, color: '#10b981' },
         { label: 'Weekly · Opus', info: liveUsage.seven_day_opus, color: '#a78bfa' },
+        { label: 'Weekly · Cowork', info: liveUsage.seven_day_cowork, color: '#22d3ee' },
       ] as const).filter((l) => l.info != null)
     : [];
+
+  const tierLabel = tier ? tier.replace(/_/g, ' ').toUpperCase() : null;
 
   return (
     <div className="card p-5 flex flex-col justify-between flex-none">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
           Plan usage
-          <InfoTip text="Your live subscription limits from Claude.ai: the 5-hour window plus the weekly all-models and Sonnet caps, each with % used and time to reset. Pulled from Anthropic's usage API." />
+          <InfoTip text="Your live subscription rate-limit ceilings from Claude.ai: the 5-hour window plus the weekly all-models, per-model and Cowork caps, each with % used and time to reset. Pulled from Anthropic's usage API — these are surfaced for awareness, not enforced." />
         </h3>
-        <span className="text-zinc-500 font-mono text-xs select-none">→</span>
+        {tierLabel ? (
+          <span className="rounded-full bg-white/5 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-zinc-400 ring-1 ring-white/10">
+            {tierLabel}
+          </span>
+        ) : (
+          <span className="text-zinc-500 font-mono text-xs select-none">→</span>
+        )}
       </div>
 
       <div className="space-y-4">
@@ -86,6 +109,12 @@ export function PlanUsage({ block, weekly, liveUsage, weekStart }: PlanUsageProp
             </span>
           </div>
           <ProgressBar pct={weeklyPct} variant="blue" />
+          {weeklyForecast && (
+            <div className="flex items-center gap-1 text-[11px]" style={{ color: weeklyForecast.color }}>
+              <span>{weeklyForecast.willExceed ? '⚠' : '↗'}</span>
+              <span>{weeklyForecast.label}</span>
+            </div>
+          )}
         </div>
 
         {/* Per-model weekly limits (shown only when the live API reports them) */}

--- a/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
+++ b/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
 import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { formatRemainingHours, formatRemainingDays, blockBarColor } from './utils';
+import { nextWeekReset } from '@/lib/week';
 import type { PlanUsageProps } from './types';
 
 const DEFAULT_BLOCK_LIMIT = 6000000; // 6.0M effective tokens
 const DEFAULT_WEEKLY_LIMIT = 35000000; // 35M effective tokens
 
-export function PlanUsage({ block, weekly, liveUsage }: PlanUsageProps) {
+export function PlanUsage({ block, weekly, liveUsage, weekStart }: PlanUsageProps) {
   const [, forceUpdate] = useState(0);
 
   useEffect(() => {
@@ -39,7 +40,10 @@ export function PlanUsage({ block, weekly, liveUsage }: PlanUsageProps) {
 
   const liveWeeklyResetsAt = hasLive ? Date.parse(liveUsage.seven_day.resets_at) : null;
   const noActiveWeekly = hasLive && liveUsage.seven_day.resets_at == null;
-  const weeklyResetsAt = liveWeeklyResetsAt && !isNaN(liveWeeklyResetsAt) ? liveWeeklyResetsAt : (weekly?.weeklyResetsAt ?? (now + 5 * 24 * 3600_000));
+  // Live Anthropic reset wins; otherwise fall back to the user's configured week start.
+  const weeklyResetsAt = liveWeeklyResetsAt && !isNaN(liveWeeklyResetsAt)
+    ? liveWeeklyResetsAt
+    : nextWeekReset(now, weekStart);
   const weeklyRemainingMs = Math.max(0, weeklyResetsAt - now);
   const weeklyResetStr = noActiveWeekly ? 'on next msg' : formatRemainingDays(weeklyRemainingMs);
 

--- a/src/components/design-system/molecules/PlanUsage/types.ts
+++ b/src/components/design-system/molecules/PlanUsage/types.ts
@@ -1,7 +1,10 @@
 import type { ActiveBlock, WeeklyData, LiveUsageData } from '@/types';
+import type { WeekStart } from '@/lib/week';
 
 export interface PlanUsageProps {
   block: ActiveBlock | null;
   weekly: WeeklyData | null;
   liveUsage?: LiveUsageData | null;
+  /** First day of the week — drives the weekly-reset countdown fallback. */
+  weekStart: WeekStart;
 }

--- a/src/components/design-system/molecules/PlanUsage/types.ts
+++ b/src/components/design-system/molecules/PlanUsage/types.ts
@@ -7,4 +7,6 @@ export interface PlanUsageProps {
   liveUsage?: LiveUsageData | null;
   /** First day of the week — drives the weekly-reset countdown fallback. */
   weekStart: WeekStart;
+  /** Plan / rate-limit tier label (e.g. "max_20x") shown as the source of these ceilings. */
+  tier?: string | null;
 }

--- a/src/components/design-system/molecules/SpendingLimits/SpendingLimits.tsx
+++ b/src/components/design-system/molecules/SpendingLimits/SpendingLimits.tsx
@@ -1,29 +1,17 @@
 import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
 import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { usd } from '@/lib/format';
+import { formatResetCountdown } from '@/lib/budget';
 import { spendingBarColor } from './utils';
 import type { SpendingLimitsProps } from './types';
 
-export function SpendingLimits({ limits, costPerDay, weekCost, alwaysShow = false, actual }: SpendingLimitsProps) {
-  const weeklyCost = weekCost ?? costPerDay * 7;
-  // When `actual` is provided, show the gateway's real billed cost (and exact
-  // month-to-date); otherwise fall back to the local-logs estimate.
-  const allRows = actual
-    ? [
-        { label: 'Today', cost: actual.today, limit: limits.dailyLimit },
-        { label: 'This week', cost: actual.week, limit: limits.weeklyLimit },
-        { label: 'This month', cost: actual.month, limit: limits.monthlyLimit },
-      ]
-    : [
-        { label: 'Today', cost: costPerDay, limit: limits.dailyLimit },
-        { label: 'This week', cost: weeklyCost, limit: limits.weeklyLimit },
-        { label: 'Monthly (est.)', cost: costPerDay * 30, limit: limits.monthlyLimit },
-      ];
-
+export function SpendingLimits({ rows, note, alwaysShow = false }: SpendingLimitsProps) {
+  const actual = rows.some((r) => r.isActual);
   // API mode shows every row (the spend is the bill); subscription mode only
   // shows rows the user has set a cap for.
-  const rows = alwaysShow ? allRows : allRows.filter((r) => r.limit != null);
-  if (rows.length === 0) return null;
+  const visible = alwaysShow ? rows : rows.filter((r) => r.cap != null);
+  if (visible.length === 0) return null;
+  const now = Date.now();
 
   return (
     <div className="card p-5">
@@ -33,40 +21,42 @@ export function SpendingLimits({ limits, costPerDay, weekCost, alwaysShow = fals
           <InfoTip
             text={
               actual
-                ? 'Real cost billed by your LiteLLM gateway (today, last 7 days, and month-to-date) against the daily/weekly/monthly USD caps you set in ⚙ Settings. Caps are stored locally in your browser.'
-                : 'Your estimated equivalent API spend against the daily/weekly/monthly USD caps you set (⚙ Settings). Caps are stored locally in your browser — this is a budgeting aid, not a real bill.'
+                ? 'Real cost billed by your LiteLLM gateway (today, this week, this month) against the daily/weekly/monthly USD caps you set in ⚙ Settings. Caps reset on real calendar boundaries and are stored locally in your browser.'
+                : 'Your estimated equivalent API spend against the daily/weekly/monthly USD caps you set (⚙ Settings). Caps reset on real calendar boundaries and are stored locally — this is a budgeting aid, not a real bill.'
             }
           />
         </h3>
-        <span className="text-xs text-zinc-600">{actual ? actual.note : 'estimated from local logs'}</span>
+        <span className="text-xs text-zinc-600">{note}</span>
       </div>
       <div className="space-y-4">
-        {rows.map(({ label, cost, limit }) => {
-          if (limit == null) {
+        {visible.map((r) => {
+          if (r.cap == null || r.pct == null) {
             // No cap set — show the figure with a gentle nudge instead of a bar.
             return (
-              <div key={label} className="flex items-center justify-between text-xs">
-                <span className="font-medium text-zinc-300">{label}</span>
+              <div key={r.key} className="flex items-center justify-between text-xs">
+                <span className="font-medium text-zinc-300">{r.label}</span>
                 <span className="font-mono text-zinc-400">
-                  {usd(cost)}{' '}
-                  <span className="text-zinc-600">· no cap set</span>
+                  {usd(r.spent)} <span className="text-zinc-600">· no cap set</span>
                 </span>
               </div>
             );
           }
-          const pct = Math.min(100, (cost / limit) * 100);
-          const color = spendingBarColor(pct);
+          const color = spendingBarColor(r.pct);
           return (
-            <div key={label}>
+            <div key={r.key}>
               <div className="mb-1.5 flex items-center justify-between text-xs">
-                <span className="font-medium text-zinc-300">{label}</span>
+                <span className="font-medium text-zinc-300">
+                  {r.label}
+                  <span className="ml-1.5 font-normal text-zinc-600">
+                    {formatResetCountdown(r.resetsAt, now)}
+                  </span>
+                </span>
                 <span className="font-mono" style={{ color }}>
-                  {usd(cost)}{' '}
-                  <span className="text-zinc-600">/ ${limit}</span>
-                  <span className="ml-1.5 text-zinc-500">({pct.toFixed(0)}%)</span>
+                  {usd(r.spent)} <span className="text-zinc-600">/ ${r.cap}</span>
+                  <span className="ml-1.5 text-zinc-500">({r.pct.toFixed(0)}%)</span>
                 </span>
               </div>
-              <ProgressBar pct={pct} color={color} />
+              <ProgressBar pct={r.pct} color={color} />
             </div>
           );
         })}

--- a/src/components/design-system/molecules/SpendingLimits/types.ts
+++ b/src/components/design-system/molecules/SpendingLimits/types.ts
@@ -1,13 +1,10 @@
-import type { Limits } from '@/hooks/useLimits';
+import type { BudgetPeriod } from '@/lib/budget';
 
 export interface SpendingLimitsProps {
-  limits: Limits;
-  costPerDay: number;
-  /** Estimated cost over the current week window; falls back to costPerDay × 7. */
-  weekCost?: number;
-  /** Always render the spend rows (even without caps) — used in API mode. */
+  /** Calendar-aligned budget periods (today / this week / this month). */
+  rows: BudgetPeriod[];
+  /** Header note, e.g. "actual · via gateway" or "estimated from local logs". */
+  note: string;
+  /** Always render rows even without a cap (API mode — the spend IS the bill). */
   alwaysShow?: boolean;
-  /** When set, rows show the real billed cost (e.g. from a LiteLLM gateway) against
-   *  the caps, instead of the local-logs estimate, and the header note reflects it. */
-  actual?: { today: number; week: number; month: number; note: string };
 }

--- a/src/components/design-system/molecules/TagEditor/TagEditor.tsx
+++ b/src/components/design-system/molecules/TagEditor/TagEditor.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { tagColor } from '@/lib/palette';
+import type { TagEditorProps } from './types';
+
+/**
+ * Inline chip editor for a project's custom tags. Stateless w.r.t. persistence —
+ * the parent owns the tag list (via useTags) and passes value/onChange, so the
+ * ProjectBreakdown rows and the TagBreakdown rollup stay in sync.
+ */
+export function TagEditor({ value, onChange, suggestions = [], placeholder = '+ tag' }: TagEditorProps) {
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  const add = (raw: string) => {
+    const t = raw.trim();
+    if (t) onChange([...value, t]);
+    setDraft('');
+    setAdding(false);
+  };
+  const remove = (tag: string) => onChange(value.filter((t) => t !== tag));
+
+  const unused = suggestions.filter((s) => !value.some((v) => v.toLowerCase() === s.toLowerCase()));
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {value.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
+          style={{ backgroundColor: `${tagColor(tag)}22`, color: tagColor(tag) }}
+        >
+          {tag}
+          <button
+            type="button"
+            onClick={() => remove(tag)}
+            className="leading-none opacity-60 transition-opacity hover:opacity-100"
+            aria-label={`Remove tag ${tag}`}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+
+      {adding ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') add(draft);
+            else if (e.key === 'Escape') {
+              setDraft('');
+              setAdding(false);
+            }
+          }}
+          onBlur={() => add(draft)}
+          maxLength={32}
+          placeholder="tag name"
+          className="w-24 rounded-full border border-white/10 bg-ink-700 px-2 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-clay-500"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="rounded-full border border-dashed border-white/15 px-2 py-0.5 text-[11px] text-zinc-500 transition-colors hover:border-clay-500 hover:text-clay-400"
+        >
+          {placeholder}
+        </button>
+      )}
+
+      {adding &&
+        unused.map((s) => (
+          <button
+            key={s}
+            type="button"
+            // mousedown fires before the input's blur, so the quick-add isn't lost
+            onMouseDown={(e) => {
+              e.preventDefault();
+              add(s);
+            }}
+            className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] text-zinc-500 transition-colors hover:text-zinc-300"
+          >
+            {s}
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/src/components/design-system/molecules/TagEditor/types.ts
+++ b/src/components/design-system/molecules/TagEditor/types.ts
@@ -1,0 +1,10 @@
+export interface TagEditorProps {
+  /** Current tags. */
+  value: string[];
+  /** Called with the next full tag list on add/remove. */
+  onChange: (tags: string[]) => void;
+  /** Existing tags elsewhere, offered as one-click quick-adds while editing. */
+  suggestions?: string[];
+  /** Label for the add affordance. */
+  placeholder?: string;
+}

--- a/src/components/design-system/organisms/ActivityHeatmap/ActivityHeatmap.tsx
+++ b/src/components/design-system/organisms/ActivityHeatmap/ActivityHeatmap.tsx
@@ -3,19 +3,22 @@ import { HoverTooltip } from '@/components/design-system/molecules/HoverTooltip/
 import type { DailyActivity } from '@/types';
 import { compact } from '@/lib/format';
 import type { ActivityHeatmapProps } from './types';
-import { MONTHS, WEEKDAYS, WEEKS, color, localKey } from './utils';
+import { MONTHS, WEEKS, color, localKey, weekdayLabels } from './utils';
 
-export function ActivityHeatmap({ days }: ActivityHeatmapProps) {
+export function ActivityHeatmap({ days, weekStart }: ActivityHeatmapProps) {
   const [hoveredDate, setHoveredDate] = useState<string | null>(null);
 
   const byDate = new Map(days.map((d) => [d.date, d]));
   const max = days.reduce((m, d) => Math.max(m, d.effectiveTokens), 0);
+  const weekdays = weekdayLabels(weekStart);
 
-  // Grid of the last WEEKS*7 days, columns = weeks (Sun-start), rows = weekday.
+  // Grid of the last WEEKS*7 days, columns = weeks (week-start aligned), rows = weekday.
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const end = new Date(today);
-  end.setDate(end.getDate() + (6 - end.getDay())); // end of current week (Sat)
+  // Advance to the last day of the current week (the day before the next week start).
+  const dow = weekStart === 'sunday' ? end.getDay() : (end.getDay() + 6) % 7;
+  end.setDate(end.getDate() + (6 - dow));
   const totalDays = WEEKS * 7;
 
   const cells: DailyActivity[] = [];
@@ -59,7 +62,7 @@ export function ActivityHeatmap({ days }: ActivityHeatmapProps) {
 
           {/* Rows 1-7: Weekdays */}
           {Array.from({ length: 7 }).map((_, rowIndex) => {
-            const weekdayLabel = WEEKDAYS[rowIndex];
+            const weekdayLabel = weekdays[rowIndex];
             return (
               <Fragment key={rowIndex}>
                 <div className="text-[10px] font-bold text-zinc-500 pr-2 flex items-center justify-end h-full min-w-[28px] select-none">

--- a/src/components/design-system/organisms/ActivityHeatmap/types.ts
+++ b/src/components/design-system/organisms/ActivityHeatmap/types.ts
@@ -1,5 +1,8 @@
 import type { DailyActivity } from '@/types';
+import type { WeekStart } from '@/lib/week';
 
 export interface ActivityHeatmapProps {
   days: DailyActivity[];
+  /** First day of the week — sets the row order and column alignment. */
+  weekStart: WeekStart;
 }

--- a/src/components/design-system/organisms/ActivityHeatmap/utils.ts
+++ b/src/components/design-system/organisms/ActivityHeatmap/utils.ts
@@ -1,6 +1,19 @@
+import type { WeekStart } from '@/lib/week';
+
 export const WEEKS = 18; // ~4 months
 export const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-export const WEEKDAYS = ['', 'Mon', '', 'Wed', '', 'Fri', '']; // rows Sun..Sat, label odd rows
+
+const SHORT_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const LABELED_DOW = new Set([1, 3, 5]); // label Mon/Wed/Fri rows, blank the rest
+
+/** Row labels (top→bottom) for the heatmap, sparse, honoring the week start. */
+export function weekdayLabels(weekStart: WeekStart): string[] {
+  const startDow = weekStart === 'sunday' ? 0 : 1;
+  return Array.from({ length: 7 }, (_, i) => {
+    const dow = (startDow + i) % 7;
+    return LABELED_DOW.has(dow) ? SHORT_DAYS[dow] : '';
+  });
+}
 
 export function localKey(d: Date): string {
   const y = d.getFullYear();

--- a/src/components/design-system/organisms/PeakHoursHeatmap/PeakHoursHeatmap.tsx
+++ b/src/components/design-system/organisms/PeakHoursHeatmap/PeakHoursHeatmap.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 import { HoverTooltip } from '@/components/design-system/molecules/HoverTooltip/HoverTooltip';
 import { compact } from '@/lib/format';
 import type { PeakHoursHeatmapProps } from './types';
-import { DAYS, HOURS, formatHour } from './utils';
+import { DAYS, HOURS, dayOrder, formatHour } from './utils';
 
-export function PeakHoursHeatmap({ grid }: PeakHoursHeatmapProps) {
+export function PeakHoursHeatmap({ grid, weekStart }: PeakHoursHeatmapProps) {
   const [tooltip, setTooltip] = useState<{ day: number; hour: number; value: number } | null>(null);
+  const rows = dayOrder(weekStart);
 
   // Find global max for intensity scaling
   const allValues = grid.flat();
@@ -34,11 +35,11 @@ export function PeakHoursHeatmap({ grid }: PeakHoursHeatmapProps) {
         ))}
       </div>
 
-      {/* Grid rows */}
-      {grid.map((row, dayIdx) => (
+      {/* Grid rows — ordered by the week-start preference (dayIdx stays canonical Mon=0..Sun=6) */}
+      {rows.map((dayIdx) => (
         <div key={dayIdx} className="flex items-center mb-0.5">
           <div className="w-10 text-[10px] text-zinc-500 font-medium shrink-0">{DAYS[dayIdx]}</div>
-          {row.map((value, hourIdx) => (
+          {grid[dayIdx].map((value, hourIdx) => (
             <div
               key={hourIdx}
               className="relative flex-1 rounded-sm cursor-default transition-opacity"

--- a/src/components/design-system/organisms/PeakHoursHeatmap/types.ts
+++ b/src/components/design-system/organisms/PeakHoursHeatmap/types.ts
@@ -1,3 +1,7 @@
+import type { WeekStart } from '@/lib/week';
+
 export interface PeakHoursHeatmapProps {
   grid: number[][];
+  /** First day of the week — sets the row order. */
+  weekStart: WeekStart;
 }

--- a/src/components/design-system/organisms/PeakHoursHeatmap/utils.ts
+++ b/src/components/design-system/organisms/PeakHoursHeatmap/utils.ts
@@ -1,5 +1,14 @@
+import type { WeekStart } from '@/lib/week';
+
+// Labels indexed by the backend grid's day index (0=Mon … 6=Sun).
 export const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 export const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+/** Backend row indices (0=Mon..6=Sun) in display order for the chosen week start. */
+export function dayOrder(weekStart: WeekStart): number[] {
+  const monFirst = [0, 1, 2, 3, 4, 5, 6];
+  return weekStart === 'sunday' ? [6, ...monFirst.slice(0, 6)] : monFirst;
+}
 
 export function formatHour(h: number): string {
   if (h === 0) return '12am';

--- a/src/components/design-system/organisms/ProjectBreakdown/ProjectBreakdown.tsx
+++ b/src/components/design-system/organisms/ProjectBreakdown/ProjectBreakdown.tsx
@@ -2,8 +2,9 @@ import { useMemo, useState } from 'react';
 import { compact, usd } from '@/lib/format';
 import { ToggleGroup } from '@/components/design-system/atoms/ToggleGroup/ToggleGroup';
 import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
-import type { ProjectBreakdownProps, LocalProjectStat } from './types';
-import { normalizePath } from './utils';
+import { TagEditor } from '@/components/design-system/molecules/TagEditor/TagEditor';
+import type { ProjectBreakdownProps } from './types';
+import { buildProjectStats } from './utils';
 
 type SortMode = 'cost' | 'time' | 'tokens' | 'files';
 
@@ -18,60 +19,12 @@ export function ProjectBreakdown({
   sessions,
   periodDays,
   projectCosts,
+  tags,
 }: ProjectBreakdownProps) {
   const [sortBy, setSortBy] = useState<SortMode>('cost');
 
-  // Build a cost lookup map keyed by normalized project name and full path
-  const costByName = useMemo(() => {
-    const m = new Map<string, number>();
-    for (const p of projectCosts ?? []) {
-      m.set(normalizePath(p.name), p.cost);
-      m.set(normalizePath(p.path), p.cost);
-    }
-    return m;
-  }, [projectCosts]);
-
   const stats = useMemo(() => {
-    const map = new Map<string, LocalProjectStat>();
-
-    for (const s of sessions) {
-      if (!s.project_path) continue;
-      const path = s.project_path;
-
-      let stat = map.get(path);
-      if (!stat) {
-        const parts = path.split(/[\\\/]/);
-        const name = parts[parts.length - 1] || path;
-        stat = {
-          path,
-          name,
-          totalTimeMinutes: 0,
-          effectiveTokens: 0,
-          cacheReadTokens: 0,
-          filesModified: 0,
-          linesAdded: 0,
-          linesRemoved: 0,
-          sessionCount: 0,
-          cost: 0,
-        };
-        map.set(path, stat);
-      }
-
-      stat.totalTimeMinutes += s.duration_minutes ?? 0;
-      stat.effectiveTokens += s.effective_tokens ?? (s.input_tokens ?? 0) + (s.output_tokens ?? 0);
-      stat.cacheReadTokens += s.cache_read_tokens ?? 0;
-      stat.filesModified += s.files_modified ?? 0;
-      stat.linesAdded += s.lines_added ?? 0;
-      stat.linesRemoved += s.lines_removed ?? 0;
-      stat.sessionCount += 1;
-    }
-
-    // Merge cost data from /api/projects using normalized paths for robust matching
-    for (const stat of map.values()) {
-      stat.cost = costByName.get(normalizePath(stat.path)) ?? costByName.get(normalizePath(stat.name)) ?? 0;
-    }
-
-    const list = [...map.values()];
+    const list = buildProjectStats(sessions, projectCosts);
 
     if (sortBy === 'cost') list.sort((a, b) => b.cost - a.cost);
     else if (sortBy === 'time') list.sort((a, b) => b.totalTimeMinutes - a.totalTimeMinutes);
@@ -79,7 +32,7 @@ export function ProjectBreakdown({
     else list.sort((a, b) => b.filesModified - a.filesModified);
 
     return list;
-  }, [sessions, sortBy, costByName]);
+  }, [sessions, sortBy, projectCosts]);
 
   const maxVal = useMemo(() => {
     if (stats.length === 0) return 1;
@@ -174,6 +127,16 @@ export function ProjectBreakdown({
                     : `+${project.linesAdded} / -${project.linesRemoved} lines`}
                 </span>
               </div>
+
+              {tags && (
+                <div className="pt-1">
+                  <TagEditor
+                    value={tags.tagsFor(project.path)}
+                    onChange={(next) => tags.setTagsFor(project.path, next)}
+                    suggestions={tags.allTags()}
+                  />
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/components/design-system/organisms/ProjectBreakdown/types.ts
+++ b/src/components/design-system/organisms/ProjectBreakdown/types.ts
@@ -1,9 +1,12 @@
 import type { SessionMeta, ProjectStat } from '@/types';
+import type { TagsApi } from '@/hooks/useTags';
 
 export interface ProjectBreakdownProps {
   sessions: SessionMeta[];
   periodDays: number;
   projectCosts?: ProjectStat[];
+  /** When provided, each project row gets an inline tag editor (WS1). */
+  tags?: TagsApi;
 }
 
 export interface LocalProjectStat {

--- a/src/components/design-system/organisms/ProjectBreakdown/utils.ts
+++ b/src/components/design-system/organisms/ProjectBreakdown/utils.ts
@@ -1,1 +1,61 @@
+import type { SessionMeta, ProjectStat } from '@/types';
+import type { LocalProjectStat } from './types';
+
 export const normalizePath = (p: string) => p.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+/**
+ * Roll session metadata (+ /api/projects cost) up into one LocalProjectStat per
+ * project path. Shared by ProjectBreakdown (sorted rows) and TagBreakdown
+ * (grouped by user tag) so both agree on per-project cost/token totals.
+ */
+export function buildProjectStats(
+  sessions: SessionMeta[],
+  projectCosts?: ProjectStat[],
+): LocalProjectStat[] {
+  // Cost lookup keyed by normalized project name AND full path for robust matching.
+  const costByName = new Map<string, number>();
+  for (const p of projectCosts ?? []) {
+    costByName.set(normalizePath(p.name), p.cost);
+    costByName.set(normalizePath(p.path), p.cost);
+  }
+
+  const map = new Map<string, LocalProjectStat>();
+  for (const s of sessions) {
+    if (!s.project_path) continue;
+    const path = s.project_path;
+
+    let stat = map.get(path);
+    if (!stat) {
+      const parts = path.split(/[\\/]/);
+      const name = parts[parts.length - 1] || path;
+      stat = {
+        path,
+        name,
+        totalTimeMinutes: 0,
+        effectiveTokens: 0,
+        cacheReadTokens: 0,
+        filesModified: 0,
+        linesAdded: 0,
+        linesRemoved: 0,
+        sessionCount: 0,
+        cost: 0,
+      };
+      map.set(path, stat);
+    }
+
+    stat.totalTimeMinutes += s.duration_minutes ?? 0;
+    stat.effectiveTokens += s.effective_tokens ?? (s.input_tokens ?? 0) + (s.output_tokens ?? 0);
+    stat.cacheReadTokens += s.cache_read_tokens ?? 0;
+    stat.filesModified += s.files_modified ?? 0;
+    stat.linesAdded += s.lines_added ?? 0;
+    stat.linesRemoved += s.lines_removed ?? 0;
+    stat.sessionCount += 1;
+  }
+
+  for (const stat of map.values()) {
+    stat.cost =
+      costByName.get(normalizePath(stat.path)) ?? costByName.get(normalizePath(stat.name)) ?? 0;
+  }
+
+  return [...map.values()];
+}

--- a/src/components/design-system/organisms/SettingsView/SettingsView.tsx
+++ b/src/components/design-system/organisms/SettingsView/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { ToggleGroup } from '@/components/design-system/atoms/ToggleGroup/ToggleGroup';
 import { PROVIDER_LABELS, PROVIDER_MODELS } from '@/hooks/useAiConfig';
 import { useSettingsForm } from '@/hooks/useSettingsForm';
+import { localeDefaultWeekStart } from '@/lib/week';
 import type { Settings } from '@/hooks/useSettings';
 import type { AiProvider } from '@/types';
 import type { SettingsViewProps } from './types';
@@ -35,6 +36,14 @@ export function SettingsView({
     { value: 'notification', label: 'Notification' },
     { value: 'sound', label: 'Notification + sound' },
   ];
+
+  const weekStartOptions: { value: Settings['weekStartDay']; label: string }[] = [
+    { value: 'auto', label: 'Auto' },
+    { value: 'sunday', label: 'Sunday' },
+    { value: 'monday', label: 'Monday' },
+  ];
+  const localeWeekStart = localeDefaultWeekStart();
+  const localeWeekStartLabel = localeWeekStart === 'sunday' ? 'Sunday' : 'Monday';
 
   const inputCls = 'w-full bg-transparent px-2 py-2 text-sm text-zinc-200 outline-none';
   const wrapCls =
@@ -79,6 +88,26 @@ export function SettingsView({
           onChange={(agentAlert) => onChangeSettings({ ...settings, agentAlert })}
           grow
         />
+      </section>
+
+      {/* ── Week start ─────────────────────────────────────────────── */}
+      <section className="mt-6 border-t border-white/10 pt-5">
+        <h4 className="mb-1 text-sm font-semibold text-zinc-300">Week start</h4>
+        <p className="mb-3 text-xs text-zinc-500">
+          First day of the week for the weekly spending window and reset countdown (and the
+          activity heatmap). Auto follows your browser locale.
+        </p>
+        <ToggleGroup<Settings['weekStartDay']>
+          options={weekStartOptions}
+          value={settings.weekStartDay}
+          onChange={(weekStartDay) => onChangeSettings({ ...settings, weekStartDay })}
+          grow
+        />
+        {settings.weekStartDay === 'auto' && (
+          <p className="mt-2 text-xs text-zinc-500">
+            Locale default: <span className="font-medium text-zinc-300">{localeWeekStartLabel}</span>
+          </p>
+        )}
       </section>
 
       {/* ── Spending limits ────────────────────────────────────────── */}

--- a/src/components/design-system/organisms/SettingsView/SettingsView.tsx
+++ b/src/components/design-system/organisms/SettingsView/SettingsView.tsx
@@ -37,6 +37,12 @@ export function SettingsView({
     { value: 'sound', label: 'Notification + sound' },
   ];
 
+  const budgetAlertOptions: { value: Settings['budgetAlert']; label: string }[] = [
+    { value: 'off', label: 'Off' },
+    { value: 'notification', label: 'Notification' },
+    { value: 'sound', label: 'Notification + sound' },
+  ];
+
   const weekStartOptions: { value: Settings['weekStartDay']; label: string }[] = [
     { value: 'auto', label: 'Auto' },
     { value: 'sunday', label: 'Sunday' },
@@ -150,6 +156,20 @@ export function SettingsView({
           >
             Save
           </button>
+        </div>
+
+        <div className="mt-5 border-t border-white/5 pt-4">
+          <h5 className="mb-1 text-xs font-semibold text-zinc-300">Budget alerts</h5>
+          <p className="mb-3 text-xs text-zinc-500">
+            Notify me the first time spend crosses 70 / 90 / 100% of a cap (resets each calendar
+            period). Caps reset on real day/week/month boundaries.
+          </p>
+          <ToggleGroup<Settings['budgetAlert']>
+            options={budgetAlertOptions}
+            value={settings.budgetAlert}
+            onChange={(budgetAlert) => onChangeSettings({ ...settings, budgetAlert })}
+            grow
+          />
         </div>
       </section>
 

--- a/src/components/design-system/organisms/TagBreakdown/TagBreakdown.tsx
+++ b/src/components/design-system/organisms/TagBreakdown/TagBreakdown.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react';
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
+import { compact, usd } from '@/lib/format';
+import { tagColor, UNTAGGED_COLOR } from '@/lib/palette';
+import { LegendDot } from '@/components/design-system/atoms/LegendDot/LegendDot';
+import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
+import type { TagBreakdownProps } from './types';
+import { groupByTag, UNTAGGED } from './utils';
+
+const labelOf = (tag: string) => (tag === UNTAGGED ? 'Untagged' : tag);
+const colorOf = (tag: string) => (tag === UNTAGGED ? UNTAGGED_COLOR : tagColor(tag));
+
+export function TagBreakdown({ sessions, projectCosts, tags }: TagBreakdownProps) {
+  const groups = useMemo(
+    () => groupByTag(sessions, projectCosts, tags),
+    // tags.tags is the underlying map — recompute when a tag is added/removed
+    [sessions, projectCosts, tags.tags], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+  const hasTags = tags.allTags().length > 0;
+
+  const data = groups.filter((g) => g.cost > 0).map((g) => ({ name: g.tag, value: g.cost }));
+  const total = data.reduce((s, d) => s + d.value, 0);
+
+  const header = (
+    <div>
+      <h3 className="flex items-center gap-1.5 text-sm font-bold uppercase tracking-wider text-zinc-300">
+        Spend by Tag
+        <InfoTip text="Estimated cost grouped by the custom tags you assign to projects on the left. A project with multiple tags counts toward each. Tags live only in your browser — nothing is sent anywhere." />
+      </h3>
+      <p className="text-xs text-zinc-500 mt-0.5">Cost attribution across your tags</p>
+    </div>
+  );
+
+  if (!hasTags) {
+    return (
+      <div className="card p-5 flex min-h-[200px] flex-col">
+        {header}
+        <div className="flex flex-1 items-center justify-center py-10 text-center text-xs italic text-zinc-500">
+          Add a tag to any project above to group its cost here.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card p-5">
+      {header}
+      <div className="mt-5 flex flex-col items-center gap-4 sm:flex-row">
+        {data.length > 0 && (
+          <div className="h-[180px] w-[180px] shrink-0">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart style={{ background: 'transparent' }}>
+                <Pie
+                  data={data}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius={52}
+                  outerRadius={80}
+                  stroke="#131318"
+                  strokeWidth={2}
+                >
+                  {data.map((d) => (
+                    <Cell key={d.name || 'untagged'} fill={colorOf(d.name)} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{
+                    background: '#1b1b22',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                    borderRadius: 12,
+                    fontSize: 12,
+                  }}
+                  itemStyle={{ color: '#e4e4e7' }}
+                  labelStyle={{ color: '#e4e4e7' }}
+                  formatter={(value: number, name: string) => [usd(value), labelOf(name)]}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        <ul className="w-full flex-1 space-y-2">
+          {groups.map((g) => (
+            <li key={g.tag || 'untagged'} className="flex items-center justify-between text-sm">
+              <LegendDot
+                color={colorOf(g.tag)}
+                label={labelOf(g.tag)}
+                size="md"
+                labelClassName="text-zinc-300"
+              />
+              <span className="tabular-nums text-zinc-400">
+                {g.cost > 0 ? usd(g.cost) : <span className="text-zinc-600">no cost</span>}
+                {total > 0 && g.cost > 0 && ` · ${((g.cost / total) * 100).toFixed(0)}%`}
+                <span className="ml-2 text-zinc-600">{compact(g.effectiveTokens)} tok</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/design-system/organisms/TagBreakdown/types.ts
+++ b/src/components/design-system/organisms/TagBreakdown/types.ts
@@ -1,0 +1,17 @@
+import type { SessionMeta, ProjectStat } from '@/types';
+import type { TagsApi } from '@/hooks/useTags';
+
+export interface TagBreakdownProps {
+  sessions: SessionMeta[];
+  projectCosts?: ProjectStat[];
+  tags: TagsApi;
+}
+
+export interface TagGroup {
+  /** Tag name, or '' for the catch-all untagged bucket. */
+  tag: string;
+  cost: number;
+  effectiveTokens: number;
+  projectCount: number;
+  sessionCount: number;
+}

--- a/src/components/design-system/organisms/TagBreakdown/utils.ts
+++ b/src/components/design-system/organisms/TagBreakdown/utils.ts
@@ -1,0 +1,45 @@
+import type { SessionMeta, ProjectStat } from '@/types';
+import type { TagsApi } from '@/hooks/useTags';
+import { buildProjectStats } from '../ProjectBreakdown/utils';
+import type { TagGroup } from './types';
+
+/** Sentinel tag for projects the user hasn't tagged. */
+export const UNTAGGED = '';
+
+/**
+ * Group per-project cost/tokens by user tag. A project with multiple tags counts
+ * toward each (mirroring LiteLLM's multi-tag attribution); untagged projects fall
+ * into the UNTAGGED bucket. Tagged groups sort by cost desc, untagged last.
+ */
+export function groupByTag(
+  sessions: SessionMeta[],
+  projectCosts: ProjectStat[] | undefined,
+  tags: TagsApi,
+): TagGroup[] {
+  const stats = buildProjectStats(sessions, projectCosts);
+  const map = new Map<string, TagGroup>();
+
+  const bump = (tag: string, cost: number, effectiveTokens: number, sessionCount: number) => {
+    let g = map.get(tag);
+    if (!g) {
+      g = { tag, cost: 0, effectiveTokens: 0, projectCount: 0, sessionCount: 0 };
+      map.set(tag, g);
+    }
+    g.cost += cost;
+    g.effectiveTokens += effectiveTokens;
+    g.projectCount += 1;
+    g.sessionCount += sessionCount;
+  };
+
+  for (const s of stats) {
+    const projTags = tags.tagsFor(s.path);
+    if (projTags.length === 0) bump(UNTAGGED, s.cost, s.effectiveTokens, s.sessionCount);
+    else for (const tag of projTags) bump(tag, s.cost, s.effectiveTokens, s.sessionCount);
+  }
+
+  return [...map.values()].sort((a, b) => {
+    if (a.tag === UNTAGGED) return 1;
+    if (b.tag === UNTAGGED) return -1;
+    return b.cost - a.cost;
+  });
+}

--- a/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
+++ b/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import type { StatCardProps } from '@/components/design-system/atoms/StatCard/types';
 import { compact, usd, shortModel, dayLabel } from '@/lib/format';
 import { modelColor } from '@/lib/palette';
+import { useConfigMode } from '@/hooks/useConfigMode';
 import { elapsedSec, formatElapsed, displayModel } from '@/components/design-system/organisms/AgentActivity/utils';
 import type { WorkflowAgentInfo, WorkflowRun, WorkflowStats } from '@/types';
 import type { WorkflowsViewProps, WorkflowCardProps } from './types';
@@ -404,6 +405,7 @@ function StatsGrid({ stats, loading }: { stats?: WorkflowStats | null; loading: 
 // ── Organism ────────────────────────────────────────────────────────────────
 
 export function WorkflowsView({ data, loading, stats, statsLoading }: WorkflowsViewProps) {
+  const { weekStart } = useConfigMode();
   const live = data?.live ?? [];
   const recent = data?.recent ?? [];
   const hasAny = live.length > 0 || recent.length > 0;
@@ -429,7 +431,7 @@ export function WorkflowsView({ data, loading, stats, statsLoading }: WorkflowsV
               </div>
             )}
             {recent.length > 0 &&
-              groupRunsByDate(recent).map((bucket) => (
+              groupRunsByDate(recent, weekStart).map((bucket) => (
                 <div key={bucket.label} className="flex flex-col gap-2">
                   <GroupLabel>{bucket.label}</GroupLabel>
                   {bucket.runs.map((r) => (

--- a/src/components/design-system/organisms/WorkflowsView/utils.ts
+++ b/src/components/design-system/organisms/WorkflowsView/utils.ts
@@ -1,4 +1,5 @@
 import type { WorkflowAgentInfo, WorkflowRun } from '@/types';
+import type { WeekStart } from '@/lib/week';
 import { compact } from '@/lib/format';
 import { formatElapsed } from '@/components/design-system/organisms/AgentActivity/utils';
 
@@ -12,15 +13,15 @@ export interface DateBucket {
  * Bucket finished runs by `startedAt` into relative date groups:
  * Today / Yesterday / Earlier this week / Earlier this month / "<Month YYYY>".
  * Fixed labels come first in that order; older month buckets follow newest-first.
- * Empty buckets are dropped. Week starts Monday (local time).
+ * Empty buckets are dropped. Week start follows the user's preference (local time).
  */
-export function groupRunsByDate(runs: WorkflowRun[]): DateBucket[] {
+export function groupRunsByDate(runs: WorkflowRun[], weekStart: WeekStart): DateBucket[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const startToday = today.getTime();
   const startYesterday = startToday - 86_400_000;
-  const mondayOffset = (today.getDay() + 6) % 7; // 0 = Monday
-  const startWeek = startToday - mondayOffset * 86_400_000;
+  const weekOffset = weekStart === 'sunday' ? today.getDay() : (today.getDay() + 6) % 7;
+  const startWeek = startToday - weekOffset * 86_400_000;
   const startMonth = new Date(today.getFullYear(), today.getMonth(), 1).getTime();
 
   const labelOf = (ts: number): string => {

--- a/src/components/tabs/LiveTab/LiveTab.tsx
+++ b/src/components/tabs/LiveTab/LiveTab.tsx
@@ -5,7 +5,7 @@ import { PlanUsage } from '@/components/design-system/molecules/PlanUsage/PlanUs
 import { SpendingLimits } from '@/components/design-system/molecules/SpendingLimits/SpendingLimits';
 import { GaugeSkeleton, ChartSkeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import { hourLabel } from '@/lib/format';
-import { sumCostThisWeek } from '@/lib/week';
+import { buildBudgetRows } from '@/lib/budget';
 import { useLiveData } from '@/hooks/useLiveData';
 import { useConfigMode } from '@/hooks/useConfigMode';
 import { useCostMetrics } from '@/hooks/useCostMetrics';
@@ -21,6 +21,15 @@ export function LiveTab({ limits }: LiveTabProps) {
   const block = recent.data?.activeBlock ?? null;
   const hasSpendingLimits =
     limits.dailyLimit != null || limits.weeklyLimit != null || limits.monthlyLimit != null;
+
+  const budgetRows = buildBudgetRows({
+    limits,
+    buckets: weekly.data?.buckets,
+    costPerDay,
+    weekStart,
+    actual: litellmActual ?? null,
+    now: Date.now(),
+  });
 
   return (
     <>
@@ -72,18 +81,22 @@ export function LiveTab({ limits }: LiveTabProps) {
 
       {/* Subscription rate-limit bars — only meaningful with a plan. */}
       {configData && !isApi && (
-        <PlanUsage block={block} weekly={weekly.data} liveUsage={liveUsage.data} weekStart={weekStart} />
+        <PlanUsage
+          block={block}
+          weekly={weekly.data}
+          liveUsage={liveUsage.data}
+          weekStart={weekStart}
+          tier={configData.subscriptionType ?? configData.rateLimitTier ?? null}
+        />
       )}
 
       {/* Spend vs caps — always shown in API mode (the cost IS the bill);
           in subscription mode only when the user has configured caps. */}
       {(isApi || hasSpendingLimits) && (
         <SpendingLimits
-          limits={limits}
-          costPerDay={costPerDay}
-          weekCost={sumCostThisWeek(weekly.data?.buckets, weekStart, Date.now())}
+          rows={budgetRows}
+          note={litellmActual?.note ?? 'estimated from local logs'}
           alwaysShow={isApi}
-          actual={litellmActual ?? undefined}
         />
       )}
     </>

--- a/src/components/tabs/LiveTab/LiveTab.tsx
+++ b/src/components/tabs/LiveTab/LiveTab.tsx
@@ -5,6 +5,7 @@ import { PlanUsage } from '@/components/design-system/molecules/PlanUsage/PlanUs
 import { SpendingLimits } from '@/components/design-system/molecules/SpendingLimits/SpendingLimits';
 import { GaugeSkeleton, ChartSkeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import { hourLabel } from '@/lib/format';
+import { sumCostThisWeek } from '@/lib/week';
 import { useLiveData } from '@/hooks/useLiveData';
 import { useConfigMode } from '@/hooks/useConfigMode';
 import { useCostMetrics } from '@/hooks/useCostMetrics';
@@ -13,7 +14,7 @@ import type { LiveTabProps } from './types';
 
 export function LiveTab({ limits }: LiveTabProps) {
   const { recent, weekly, liveUsage, recentHours, setRecentHours } = useLiveData();
-  const { configData, isApi } = useConfigMode();
+  const { configData, isApi, weekStart } = useConfigMode();
   const { costPerDay } = useCostMetrics();
   const { litellmActual } = useLiteLlmActual();
 
@@ -71,7 +72,7 @@ export function LiveTab({ limits }: LiveTabProps) {
 
       {/* Subscription rate-limit bars — only meaningful with a plan. */}
       {configData && !isApi && (
-        <PlanUsage block={block} weekly={weekly.data} liveUsage={liveUsage.data} />
+        <PlanUsage block={block} weekly={weekly.data} liveUsage={liveUsage.data} weekStart={weekStart} />
       )}
 
       {/* Spend vs caps — always shown in API mode (the cost IS the bill);
@@ -80,7 +81,7 @@ export function LiveTab({ limits }: LiveTabProps) {
         <SpendingLimits
           limits={limits}
           costPerDay={costPerDay}
-          weekCost={weekly.data?.totals.cost}
+          weekCost={sumCostThisWeek(weekly.data?.buckets, weekStart, Date.now())}
           alwaysShow={isApi}
           actual={litellmActual ?? undefined}
         />

--- a/src/components/tabs/SessionsTab/SessionsTab.tsx
+++ b/src/components/tabs/SessionsTab/SessionsTab.tsx
@@ -1,11 +1,13 @@
 import { ConfigProfile } from '@/components/design-system/organisms/ConfigProfile/ConfigProfile';
 import { ProjectBreakdown } from '@/components/design-system/organisms/ProjectBreakdown/ProjectBreakdown';
+import { TagBreakdown } from '@/components/design-system/organisms/TagBreakdown/TagBreakdown';
 import { SessionHistoryTable } from '@/components/design-system/organisms/SessionHistoryTable/SessionHistoryTable';
 import { Skeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import { usePolling } from '@/hooks/usePolling';
 import { useSource } from '@/hooks/useSource';
 import { useConfigMode } from '@/hooks/useConfigMode';
 import { useSessionPeriod } from '@/hooks/useSessionPeriod';
+import { useTags } from '@/hooks/useTags';
 import type { SessionMeta, ProjectData } from '@/types';
 
 export function SessionsTab() {
@@ -14,6 +16,7 @@ export function SessionsTab() {
   const sessions = usePolling<SessionMeta[]>(withSrc('/api/sessions'), 10000);
   const projectCosts = usePolling<ProjectData>(withSrc('/api/projects?days=90'), 30000);
   const totalPeriodDays = useSessionPeriod(sessions.data);
+  const tags = useTags();
 
   return (
     <>
@@ -37,6 +40,7 @@ export function SessionsTab() {
                 sessions={sessions.data}
                 periodDays={totalPeriodDays}
                 projectCosts={projectCosts.data?.projects}
+                tags={tags}
               />
             ) : sessions.loading ? (
               <div className="card p-5">
@@ -45,6 +49,14 @@ export function SessionsTab() {
             ) : null}
           </div>
         </div>
+      )}
+
+      {source !== 'cowork' && sessions.data && (
+        <TagBreakdown
+          sessions={sessions.data}
+          projectCosts={projectCosts.data?.projects}
+          tags={tags}
+        />
       )}
 
       {sessions.data ? (

--- a/src/components/tabs/TrendsTab/TrendsTab.tsx
+++ b/src/components/tabs/TrendsTab/TrendsTab.tsx
@@ -138,7 +138,7 @@ export function TrendsTab() {
         help="Effective tokens summed into a 7-day × 24-hour grid (your local time). Darker cells are your busiest hours — when you use Claude most."
       >
         {heatmap.data ? (
-          <PeakHoursHeatmap grid={heatmap.data.grid} />
+          <PeakHoursHeatmap grid={heatmap.data.grid} weekStart={weekStart} />
         ) : heatmap.loading ? (
           <HeatmapSkeleton />
         ) : (

--- a/src/components/tabs/TrendsTab/TrendsTab.tsx
+++ b/src/components/tabs/TrendsTab/TrendsTab.tsx
@@ -21,7 +21,7 @@ import type { ActivityData, HeatmapData } from '@/types';
 
 export function TrendsTab() {
   const { coworkAvailable, source, withSrc } = useSource();
-  const { litellmAvailable, litellmHost } = useConfigMode();
+  const { litellmAvailable, litellmHost, weekStart } = useConfigMode();
   const { weekly, models, weekDays, setWeekDays } = useLiveData();
   const { costPerDay, daysLeftInMonth, projectedMonthCost, weeklyEffective, prevWeeklyEffective } =
     useCostMetrics();
@@ -152,7 +152,7 @@ export function TrendsTab() {
         help="GitHub-style calendar: one square per day, darker = more effective tokens used. Shows your day-to-day usage streaks over the last ~18 weeks."
       >
         {activity.data ? (
-          <ActivityHeatmap days={activity.data.dailyActivity} />
+          <ActivityHeatmap days={activity.data.dailyActivity} weekStart={weekStart} />
         ) : activity.loading ? (
           <HeatmapSkeleton />
         ) : null}

--- a/src/components/tabs/TrendsTab/TrendsTab.tsx
+++ b/src/components/tabs/TrendsTab/TrendsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { StatCard } from '@/components/design-system/atoms/StatCard/StatCard';
 import { Section } from '@/components/design-system/molecules/Section/Section';
+import { ExportButton } from '@/components/design-system/molecules/ExportButton/ExportButton';
 import { CacheEfficiencyChart } from '@/components/design-system/organisms/CacheEfficiencyChart/CacheEfficiencyChart';
 import { PeakHoursHeatmap } from '@/components/design-system/organisms/PeakHoursHeatmap/PeakHoursHeatmap';
 import { ActivityHeatmap } from '@/components/design-system/organisms/ActivityHeatmap/ActivityHeatmap';
@@ -10,6 +11,7 @@ import { DailyTrendChart } from '@/components/design-system/organisms/DailyTrend
 import type { DailyMetric } from '@/components/design-system/organisms/DailyTrendChart/types';
 import { StatCardSkeleton, HeatmapSkeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import { compact, usd, shortModel } from '@/lib/format';
+import { buildSpendReport } from '@/lib/report';
 import { usePolling } from '@/hooks/usePolling';
 import { useSource } from '@/hooks/useSource';
 import { useConfigMode } from '@/hooks/useConfigMode';
@@ -39,18 +41,24 @@ export function TrendsTab() {
           and (when present) the LiteLLM actual-billed chart. */}
       <div className="flex items-center justify-between">
         <span className="text-xs uppercase tracking-wider text-zinc-500">Spending · last {weekDays} days</span>
-        <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
-          {[7, 14, 21, 28].map((d) => (
-            <button
-              key={d}
-              onClick={() => setWeekDays(d)}
-              className={`px-2.5 py-1 text-xs tabular-nums transition-colors ${
-                weekDays === d ? 'bg-clay-500/20 text-clay-400' : 'text-zinc-500 hover:text-zinc-300'
-              }`}
-            >
-              {d / 7}w
-            </button>
-          ))}
+        <div className="flex items-center gap-3">
+          <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
+            {[7, 14, 21, 28].map((d) => (
+              <button
+                key={d}
+                onClick={() => setWeekDays(d)}
+                className={`px-2.5 py-1 text-xs tabular-nums transition-colors ${
+                  weekDays === d ? 'bg-clay-500/20 text-clay-400' : 'text-zinc-500 hover:text-zinc-300'
+                }`}
+              >
+                {d / 7}w
+              </button>
+            ))}
+          </div>
+          <ExportButton
+            label="Spend report"
+            getData={() => (weekly.data ? buildSpendReport(weekly.data, weekDays, source) : null)}
+          />
         </div>
       </div>
       {/* Cost stat cards */}

--- a/src/hooks/useBudgetAlerts.ts
+++ b/src/hooks/useBudgetAlerts.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react';
+import type { Settings } from './useSettings';
+import type { BudgetPeriod } from '@/lib/budget';
+
+const THRESHOLDS = [70, 90, 100] as const;
+
+/** Short WebAudio chime — no asset needed. Best-effort; silent on failure.
+ *  (Mirrors useAgentAlerts' chime; kept local so each alert hook is self-contained.) */
+function playChime() {
+  try {
+    const Ctx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'sine';
+    osc.frequency.value = 660;
+    gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.2, ctx.currentTime + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.4);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.42);
+    osc.onended = () => ctx.close();
+  } catch {
+    /* audio unavailable — ignore */
+  }
+}
+
+const TITLES: Record<BudgetPeriod['key'], string> = {
+  day: 'Daily',
+  week: 'Weekly',
+  month: 'Monthly',
+};
+
+/**
+ * Soft (non-blocking) budget alerts — LiteLLM-inspired. Fires a browser
+ * notification (and optional chime) the first time spend crosses 70 / 90 / 100%
+ * of a cap, deduped per period per calendar window: each threshold fires once,
+ * and tracking resets when the period rolls over (a new resetsAt). 'off' is a
+ * no-op. Mirrors useBlockAlerts' permission-request pattern.
+ */
+export function useBudgetAlerts(rows: BudgetPeriod[], mode: Settings['budgetAlert']) {
+  // key → { window: resetsAt of the window we last alerted in, level: highest threshold fired }
+  const fired = useRef<Record<string, { window: number; level: number }>>({});
+
+  useEffect(() => {
+    if (mode === 'off') return;
+    if (!('Notification' in window)) return;
+    if (Notification.permission === 'default') void Notification.requestPermission();
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode === 'off') return;
+    if (!('Notification' in window) || Notification.permission !== 'granted') return;
+
+    for (const r of rows) {
+      if (r.pct == null) continue; // no cap configured
+
+      const prev = fired.current[r.key];
+      // Reset the high-water mark when this period rolls into a new window.
+      const baseLevel = prev && prev.window === r.resetsAt ? prev.level : 0;
+      let level = baseLevel;
+
+      for (const t of THRESHOLDS) {
+        if (r.pct >= t && level < t) {
+          level = t;
+          new Notification(
+            t === 100 ? `${TITLES[r.key]} budget reached` : `${TITLES[r.key]} budget at ${t}%`,
+            {
+              body:
+                t === 100
+                  ? `You've hit your ${r.key} spend cap of $${r.cap}.`
+                  : `You've used ${Math.round(r.pct)}% of your ${r.key} spend cap.`,
+              icon: '/favicon.ico',
+              tag: `claude-budget-${r.key}`,
+            },
+          );
+          if (mode === 'sound') playChime();
+        }
+      }
+
+      if (!prev || prev.window !== r.resetsAt || level !== prev.level) {
+        fired.current[r.key] = { window: r.resetsAt, level };
+      }
+    }
+  }, [rows, mode]);
+}

--- a/src/hooks/useConfigMode.tsx
+++ b/src/hooks/useConfigMode.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { usePolling } from './usePolling';
 import { useSettings } from './useSettings';
 import type { Settings } from './useSettings';
+import { localeDefaultWeekStart } from '../lib/week';
+import type { WeekStart } from '../lib/week';
 import type { ClaudeConfig } from '../types';
 
 type AuthMode = 'api' | 'subscription';
@@ -17,6 +19,8 @@ interface ConfigModeCtx {
   isApi: boolean;
   litellmAvailable: boolean;
   litellmHost: string;
+  /** First day of the week, resolved from settings ('auto' → browser locale). */
+  weekStart: WeekStart;
   settings: Settings;
   setSettings: (s: Settings) => void;
 }
@@ -43,6 +47,7 @@ export function ConfigModeProvider({ children }: { children: ReactNode }) {
       isApi: effectiveMode === 'api',
       litellmAvailable: !!config.data?.litellm?.available,
       litellmHost: config.data?.litellm?.gatewayHost ?? '',
+      weekStart: settings.weekStartDay === 'auto' ? localeDefaultWeekStart() : settings.weekStartDay,
       settings,
       setSettings,
     };

--- a/src/hooks/useDashboardNotifications.ts
+++ b/src/hooks/useDashboardNotifications.ts
@@ -1,25 +1,48 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { track, setUserContext } from '../lib/analytics';
+import { buildBudgetRows } from '../lib/budget';
 import { useNotifications } from './useNotifications';
 import { useUpdateToast } from './useUpdateToast';
 import { useConfigMode } from './useConfigMode';
 import { useLiveData } from './useLiveData';
+import { useLiteLlmActual } from './useLiteLlmActual';
+import { useCostMetrics } from './useCostMetrics';
 import { useAgentTraffic } from './useAgentTraffic';
 import { useAgentAlerts } from './useAgentAlerts';
+import { useBudgetAlerts } from './useBudgetAlerts';
+import type { Limits } from './useLimits';
 
 /**
  * App-level side effects: anonymous analytics + the toast notifications that
  * replaced the old inline banners (update available, Claude.ai offline/expired,
  * pay-as-you-go note). Kept out of the render tree so App stays a thin shell.
  */
-export function useDashboardNotifications(activeTab: string) {
-  const { configData, effectiveMode, isApi, settings } = useConfigMode();
-  const { liveUsage, version } = useLiveData();
+export function useDashboardNotifications(activeTab: string, limits: Limits) {
+  const { configData, effectiveMode, isApi, settings, weekStart } = useConfigMode();
+  const { liveUsage, version, weekly } = useLiveData();
+  const { litellmActual } = useLiteLlmActual();
+  const { costPerDay } = useCostMetrics();
   const { notify, dismiss } = useNotifications();
   const { waiting } = useAgentTraffic();
   useUpdateToast(version.data);
   // Alert (per Settings) when a new agent turns red / needs attention.
   useAgentAlerts(waiting, settings.agentAlert);
+
+  // Soft (non-blocking) budget alerts (LiteLLM-inspired) — fire app-wide, not
+  // just on the Live tab, the first time spend crosses a cap threshold.
+  const budgetRows = useMemo(
+    () =>
+      buildBudgetRows({
+        limits,
+        buckets: weekly.data?.buckets,
+        costPerDay,
+        weekStart,
+        actual: litellmActual ?? null,
+        now: Date.now(),
+      }),
+    [limits, weekly.data?.buckets, costPerDay, weekStart, litellmActual],
+  );
+  useBudgetAlerts(budgetRows, settings.budgetAlert);
 
   // ── Product analytics (anonymous, path-free events only — see lib/analytics) ──
   useEffect(() => {

--- a/src/hooks/useLiteLlmActual.ts
+++ b/src/hooks/useLiteLlmActual.ts
@@ -1,5 +1,6 @@
 import { useLiveData } from './useLiveData';
 import { useConfigMode } from './useConfigMode';
+import { localYmd, startOfWeek } from '../lib/week';
 import type { LiteLlmSpend } from '../types';
 
 /** Real billed cost slices for the Live-tab spend widgets / daily-cap ring. */
@@ -20,18 +21,19 @@ export interface LiteLlmActualResult {
  * Actual billed spend from the LiteLLM gateway. Both values are null when no
  * gateway is configured or the report errored, so callers can hide the cards and
  * the dashboard degrades gracefully. Today = the most recent daily entry;
- * week = the last 7 of the daily series.
+ * week = the current calendar week (per the user's first-day-of-week preference).
  */
 export function useLiteLlmActual(): LiteLlmActualResult {
   const { litellm } = useLiveData();
-  const { litellmAvailable, litellmHost } = useConfigMode();
+  const { litellmAvailable, litellmHost, weekStart } = useConfigMode();
 
   const litellmSpend = litellm.data && !('error' in litellm.data) ? litellm.data : null;
+  const weekFromYmd = localYmd(startOfWeek(Date.now(), weekStart));
   const litellmActual =
     litellmAvailable && litellmSpend
       ? {
           today: litellmSpend.daily[litellmSpend.daily.length - 1]?.cost ?? 0,
-          week: litellmSpend.daily.slice(-7).reduce((s, d) => s + d.cost, 0),
+          week: litellmSpend.daily.reduce((s, d) => (d.date >= weekFromYmd ? s + d.cost : s), 0),
           month: litellmSpend.monthToDate,
           note: litellmHost ? `actual · via ${litellmHost}` : 'actual billed',
         }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -8,6 +8,9 @@ export interface Settings {
   // How to alert when an agent turns red (waiting for confirmation/attention):
   // visual badge only, + browser notification, or + an audible chime.
   agentAlert: 'visual' | 'notification' | 'sound';
+  // How to alert when spend crosses a budget cap threshold (70/90/100%):
+  // off, a browser notification, or notification + an audible chime.
+  budgetAlert: 'off' | 'notification' | 'sound';
   // First day of the week for weekly windows/reset. 'auto' resolves from the
   // browser locale (see useConfigMode → weekStart).
   weekStartDay: 'auto' | 'sunday' | 'monday';
@@ -18,6 +21,7 @@ const KEY = 'claude-dashboard-settings-v1';
 const DEFAULTS: Settings = {
   modeOverride: 'auto',
   agentAlert: 'notification',
+  budgetAlert: 'notification',
   weekStartDay: 'auto',
 };
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -8,11 +8,18 @@ export interface Settings {
   // How to alert when an agent turns red (waiting for confirmation/attention):
   // visual badge only, + browser notification, or + an audible chime.
   agentAlert: 'visual' | 'notification' | 'sound';
+  // First day of the week for weekly windows/reset. 'auto' resolves from the
+  // browser locale (see useConfigMode → weekStart).
+  weekStartDay: 'auto' | 'sunday' | 'monday';
 }
 
 const KEY = 'claude-dashboard-settings-v1';
 
-const DEFAULTS: Settings = { modeOverride: 'auto', agentAlert: 'notification' };
+const DEFAULTS: Settings = {
+  modeOverride: 'auto',
+  agentAlert: 'notification',
+  weekStartDay: 'auto',
+};
 
 function load(): Settings {
   try {

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react';
+
+/** Project-path → custom tags. Persisted client-side only (privacy: never sent to backend). */
+export type TagMap = Record<string, string[]>;
+
+const KEY = 'claude-dashboard-tags-v1';
+const MAX_TAG_LEN = 32;
+
+function load(): TagMap {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) ?? 'null');
+    return raw && typeof raw === 'object' ? (raw as TagMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+export interface TagsApi {
+  /** Raw path → tags map (stable identity until a mutation). */
+  tags: TagMap;
+  /** Tags for one project path (always an array, never undefined). */
+  tagsFor: (path: string) => string[];
+  /** Replace the tag set for a project path; an empty result clears the entry. */
+  setTagsFor: (path: string, tags: string[]) => void;
+  /** Every distinct tag in use, sorted. */
+  allTags: () => string[];
+}
+
+/**
+ * User-defined project tags for LiteLLM-style cost attribution. Mirrors the
+ * useLimits/useSettings localStorage pattern — purely client-side, so it works
+ * against the read-only ~/.claude mount and keeps project paths on the machine.
+ */
+export function useTags(): TagsApi {
+  const [tags, setTags] = useState<TagMap>(load);
+
+  const persist = useCallback((next: TagMap) => {
+    setTags(next);
+    try {
+      localStorage.setItem(KEY, JSON.stringify(next));
+    } catch {
+      /* localStorage unavailable — best effort */
+    }
+  }, []);
+
+  const tagsFor = useCallback((path: string) => tags[path] ?? [], [tags]);
+
+  const setTagsFor = useCallback(
+    (path: string, list: string[]) => {
+      // Trim, drop empties, cap length, dedupe case-insensitively.
+      const seen = new Set<string>();
+      const clean: string[] = [];
+      for (const raw of list) {
+        const t = raw.trim().slice(0, MAX_TAG_LEN);
+        if (!t) continue;
+        const k = t.toLowerCase();
+        if (seen.has(k)) continue;
+        seen.add(k);
+        clean.push(t);
+      }
+      const next = { ...tags };
+      if (clean.length) next[path] = clean;
+      else delete next[path];
+      persist(next);
+    },
+    [tags, persist],
+  );
+
+  const allTags = useCallback(() => {
+    const set = new Set<string>();
+    for (const list of Object.values(tags)) for (const t of list) set.add(t);
+    return [...set].sort((a, b) => a.localeCompare(b));
+  }, [tags]);
+
+  return { tags, tagsFor, setTagsFor, allTags };
+}

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -1,0 +1,85 @@
+import type { Limits } from '@/hooks/useLimits';
+import type { WeekStart } from './week';
+import { nextDayReset, nextWeekReset, nextMonthReset, sumCostToday, sumCostThisWeek } from './week';
+
+/** One calendar budget period (day/week/month) with spend vs an optional cap. */
+export interface BudgetPeriod {
+  key: 'day' | 'week' | 'month';
+  label: string;
+  /** Spend so far in the current calendar period. */
+  spent: number;
+  /** USD cap, or null when the user hasn't set one. */
+  cap: number | null;
+  /** Spend ÷ cap as a 0–100 percentage, or null when there's no cap. */
+  pct: number | null;
+  /** Epoch ms when this calendar period rolls over. */
+  resetsAt: number;
+  /** True when `spent` is real billed cost (gateway), false for the local estimate. */
+  isActual: boolean;
+}
+
+export interface BudgetInput {
+  limits: Limits;
+  /** Daily cost buckets (from /api/usage/weekly) for the estimate path. */
+  buckets?: { start: number; cost: number }[];
+  /** Average $/day over the window — used for the month-to-date estimate. */
+  costPerDay: number;
+  weekStart: WeekStart;
+  /** Real billed slices (LiteLLM gateway); when present they override the estimate. */
+  actual?: { today: number; week: number; month: number } | null;
+  now: number;
+}
+
+/**
+ * Per-period spend vs caps, aligned to real calendar boundaries (today / this
+ * week per the week-start preference / this month). Prefers real billed spend
+ * when a gateway report is available; otherwise estimates from local logs. The
+ * month-to-date estimate uses costPerDay × day-of-month because the weekly
+ * buckets only span the recent window, not the whole month.
+ */
+export function buildBudgetRows({
+  limits,
+  buckets,
+  costPerDay,
+  weekStart,
+  actual,
+  now,
+}: BudgetInput): BudgetPeriod[] {
+  const isActual = !!actual;
+  const dayOfMonth = new Date(now).getDate();
+
+  const today = actual ? actual.today : sumCostToday(buckets, now);
+  const week = actual ? actual.week : sumCostThisWeek(buckets, weekStart, now);
+  const month = actual ? actual.month : costPerDay * dayOfMonth;
+
+  const row = (
+    key: BudgetPeriod['key'],
+    label: string,
+    spent: number,
+    cap: number | null,
+    resetsAt: number,
+  ): BudgetPeriod => ({
+    key,
+    label,
+    spent,
+    cap,
+    pct: cap != null && cap > 0 ? Math.min(100, (spent / cap) * 100) : null,
+    resetsAt,
+    isActual,
+  });
+
+  return [
+    row('day', 'Today', today, limits.dailyLimit, nextDayReset(now)),
+    row('week', 'This week', week, limits.weeklyLimit, nextWeekReset(now, weekStart)),
+    row('month', 'This month', month, limits.monthlyLimit, nextMonthReset(now)),
+  ];
+}
+
+/** Compact "resets in 4h" / "resets in 3d" countdown for a budget period. */
+export function formatResetCountdown(resetsAt: number, now: number): string {
+  const ms = Math.max(0, resetsAt - now);
+  const h = ms / 3_600_000;
+  if (h < 1) return `resets in ${Math.max(1, Math.round(ms / 60_000))}m`;
+  if (h < 24) return `resets in ${Math.round(h)}h`;
+  return `resets in ${Math.round(h / 24)}d`;
+}

--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -1,0 +1,61 @@
+/** Linear projection of weekly limit usage at reset, given the current pace. */
+export interface WeeklyForecast {
+  /** Extrapolated utilization (%) at the reset moment. */
+  projectedPct: number;
+  /** True when projected to cross 100% before the weekly window resets. */
+  willExceed: boolean;
+  /** Compact display string, e.g. "on track · ~72% by reset" or "limit in ~2d". */
+  label: string;
+  /** Severity color for the label. */
+  color: string;
+}
+
+function formatEta(ms: number): string {
+  if (ms < 3_600_000) return `${Math.max(1, Math.round(ms / 60_000))}m`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h`;
+  return `${Math.round(ms / 86_400_000)}d`;
+}
+
+/**
+ * Project where weekly usage lands by the reset if the current burn rate holds.
+ * A naive linear extrapolation: usage so far ÷ fraction-of-window-elapsed. Returns
+ * null when it's too early to say (the window just started) or the inputs are
+ * degenerate. This is the cross-window analog to BlockGauge's single-block ETA.
+ */
+export function buildWeeklyForecast(input: {
+  /** Current weekly utilization, 0–100. */
+  pct: number;
+  /** Epoch ms the weekly window began. */
+  windowStart: number;
+  /** Epoch ms the weekly window resets. */
+  resetsAt: number;
+  now: number;
+}): WeeklyForecast | null {
+  const { pct, windowStart, resetsAt, now } = input;
+  if (resetsAt <= now || windowStart >= now) return null;
+
+  const elapsed = now - windowStart;
+  const total = resetsAt - windowStart;
+  if (elapsed < 30 * 60_000 || total <= 0) return null; // too early to extrapolate
+
+  const elapsedFrac = elapsed / total;
+  const projectedPct = elapsedFrac > 0 ? pct / elapsedFrac : pct;
+
+  if (pct >= 100) {
+    return { projectedPct: 100, willExceed: true, label: 'weekly limit reached', color: '#ef4444' };
+  }
+
+  if (projectedPct >= 100 && pct > 0) {
+    // Remaining time until usage hits 100% at the current pace.
+    const msTo100 = (100 / pct) * elapsed - elapsed;
+    const color = msTo100 < 86_400_000 ? '#ef4444' : '#f59e0b';
+    return { projectedPct, willExceed: true, label: `on pace to hit limit in ~${formatEta(msTo100)}`, color };
+  }
+
+  return {
+    projectedPct,
+    willExceed: false,
+    label: `on track · ~${Math.round(projectedPct)}% by reset`,
+    color: '#71717a',
+  };
+}

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -12,3 +12,21 @@ export function modelColor(model: string): string {
   }
   return c;
 }
+
+// Separate assigner so user tags get stable, distinct colors without sharing the
+// model color map (which would make a tag and a model collide on the same hue).
+const tagAssigned = new Map<string, string>();
+let tagNext = 0;
+
+/** Neutral gray for the catch-all "Untagged" bucket — never drawn from the palette. */
+export const UNTAGGED_COLOR = '#52525b';
+
+export function tagColor(tag: string): string {
+  let c = tagAssigned.get(tag);
+  if (!c) {
+    c = COLORS[tagNext % COLORS.length];
+    tagNext += 1;
+    tagAssigned.set(tag, c);
+  }
+  return c;
+}

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -1,0 +1,58 @@
+import type { WeeklyData } from '@/types';
+import { localYmd } from './week';
+import { shortModel } from './format';
+
+/** Shape ExportButton consumes: a flat CSV table, a structured JSON doc, a slug. */
+export interface SpendReport {
+  csv: Record<string, unknown>[];
+  json: unknown;
+  filename: string;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * On-demand spend report from the selected Trends window (LiteLLM-inspired
+ * scheduled reports, minus the scheduling — emailing reports would leave the
+ * machine, which the local-first model forbids). CSV = the per-day table; JSON =
+ * the full report (summary + per-day + per-model). All figures are estimated
+ * equivalent-API cost, since subscription usage has no per-token bill.
+ */
+export function buildSpendReport(weekly: WeeklyData, weekDays: number, source: string): SpendReport {
+  const perDay = weekly.buckets.map((b) => ({
+    date: localYmd(b.start),
+    costUSD: round2(b.cost),
+    effectiveTokens: b.effectiveTokens,
+    inputTokens: b.inputTokens,
+    outputTokens: b.outputTokens,
+    cacheCreateTokens: b.cacheCreateTokens,
+    cacheReadTokens: b.cacheReadTokens,
+    totalTokens: b.totalTokens,
+  }));
+
+  const perModel = weekly.byModel.map((m) => ({
+    model: m.model,
+    shortModel: shortModel(m.model),
+    costUSD: round2(m.cost),
+    effectiveTokens: m.effectiveTokens,
+    totalTokens: m.totalTokens,
+  }));
+
+  const summary = {
+    windowDays: weekDays,
+    from: localYmd(weekly.rangeFrom),
+    to: localYmd(weekly.rangeTo),
+    source,
+    costBasis: 'estimated-equivalent-api',
+    totalCostUSD: round2(weekly.totals.cost),
+    avgCostPerDayUSD: round2(weekly.totals.cost / weekDays),
+    effectiveTokens: weekly.totals.effectiveTokens,
+    totalTokens: weekly.totals.totalTokens,
+  };
+
+  return {
+    csv: perDay,
+    json: { summary, perDay, perModel },
+    filename: `spend-report-${weekDays}d`,
+  };
+}

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -1,0 +1,63 @@
+/** First-day-of-week preference, resolved to a concrete day (never 'auto'). */
+export type WeekStart = 'sunday' | 'monday';
+
+/**
+ * Best-effort first day of the week from the browser locale via `Intl.Locale`
+ * week info (`firstDay`: 1=Mon … 7=Sun). Falls back to Monday when the API is
+ * unavailable, which preserves the dashboard's previous fixed behaviour.
+ */
+export function localeDefaultWeekStart(): WeekStart {
+  try {
+    const lang = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+    // `weekInfo` (property) and `getWeekInfo()` (method) both ship across engines.
+    const loc = new Intl.Locale(lang) as Intl.Locale & {
+      weekInfo?: { firstDay: number };
+      getWeekInfo?: () => { firstDay: number };
+    };
+    const info = typeof loc.getWeekInfo === 'function' ? loc.getWeekInfo() : loc.weekInfo;
+    return info?.firstDay === 7 ? 'sunday' : 'monday';
+  } catch {
+    return 'monday';
+  }
+}
+
+/** Day-of-week index (0=Sun, 1=Mon) the week begins on. */
+function startDow(ws: WeekStart): number {
+  return ws === 'sunday' ? 0 : 1;
+}
+
+/** Local-midnight timestamp of the current week's first day. */
+export function startOfWeek(now: number, ws: WeekStart): number {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  const offset = (d.getDay() - startDow(ws) + 7) % 7;
+  d.setDate(d.getDate() - offset);
+  return d.getTime();
+}
+
+/** Local-midnight timestamp of the next week's first day (reset countdown). */
+export function nextWeekReset(now: number, ws: WeekStart): number {
+  const d = new Date(startOfWeek(now, ws));
+  d.setDate(d.getDate() + 7);
+  return d.getTime();
+}
+
+/** Local YYYY-MM-DD key for a timestamp (matches the gateway's daily date keys). */
+export function localYmd(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Sum daily-bucket cost for buckets whose start falls in the current week. */
+export function sumCostThisWeek(
+  buckets: { start: number; cost: number }[] | undefined,
+  ws: WeekStart,
+  now: number,
+): number {
+  if (!buckets) return 0;
+  const from = startOfWeek(now, ws);
+  return buckets.reduce((s, b) => (b.start >= from ? s + b.cost : s), 0);
+}

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -26,6 +26,20 @@ function startDow(ws: WeekStart): number {
   return ws === 'sunday' ? 0 : 1;
 }
 
+/** Local-midnight timestamp of today. */
+export function startOfDay(now: number): number {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/** Local-midnight timestamp of tomorrow (daily reset countdown). */
+export function nextDayReset(now: number): number {
+  const d = new Date(startOfDay(now));
+  d.setDate(d.getDate() + 1);
+  return d.getTime();
+}
+
 /** Local-midnight timestamp of the current week's first day. */
 export function startOfWeek(now: number, ws: WeekStart): number {
   const d = new Date(now);
@@ -42,6 +56,21 @@ export function nextWeekReset(now: number, ws: WeekStart): number {
   return d.getTime();
 }
 
+/** Local-midnight timestamp of the first day of the current month. */
+export function startOfMonth(now: number): number {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(1);
+  return d.getTime();
+}
+
+/** Local-midnight timestamp of the first day of next month (reset countdown). */
+export function nextMonthReset(now: number): number {
+  const d = new Date(startOfMonth(now));
+  d.setMonth(d.getMonth() + 1);
+  return d.getTime();
+}
+
 /** Local YYYY-MM-DD key for a timestamp (matches the gateway's daily date keys). */
 export function localYmd(ms: number): string {
   const d = new Date(ms);
@@ -51,13 +80,33 @@ export function localYmd(ms: number): string {
   return `${y}-${m}-${day}`;
 }
 
+/** Sum daily-bucket cost for buckets whose start is at/after `from`. */
+function sumCostSince(buckets: { start: number; cost: number }[] | undefined, from: number): number {
+  if (!buckets) return 0;
+  return buckets.reduce((s, b) => (b.start >= from ? s + b.cost : s), 0);
+}
+
+/** Sum daily-bucket cost for buckets whose start falls today. */
+export function sumCostToday(
+  buckets: { start: number; cost: number }[] | undefined,
+  now: number,
+): number {
+  return sumCostSince(buckets, startOfDay(now));
+}
+
 /** Sum daily-bucket cost for buckets whose start falls in the current week. */
 export function sumCostThisWeek(
   buckets: { start: number; cost: number }[] | undefined,
   ws: WeekStart,
   now: number,
 ): number {
-  if (!buckets) return 0;
-  const from = startOfWeek(now, ws);
-  return buckets.reduce((s, b) => (b.start >= from ? s + b.cost : s), 0);
+  return sumCostSince(buckets, startOfWeek(now, ws));
+}
+
+/** Sum daily-bucket cost for buckets whose start falls in the current month. */
+export function sumCostThisMonth(
+  buckets: { start: number; cost: number }[] | undefined,
+  now: number,
+): number {
+  return sumCostSince(buckets, startOfMonth(now));
 }


### PR DESCRIPTION
## What & why

Adds four **observability/reporting** features inspired by a deep-research comparison of the [LiteLLM](https://www.litellm.ai/) product against this local-first dashboard. LiteLLM's request-path half — virtual keys, guardrails, routing, **hard budget / TPM-RPM enforcement**, and **multi-tenant per-user/team/customer attribution** — is architecturally impossible for a read-only `~/.claude` JSONL parser, so only the transferable reporting side is implemented.

All new config is **localStorage-persisted** (the `~/.claude` mount is read-only). **No backend changes.**

## Features

| Feature | Summary | Key files |
|---|---|---|
| **Tagging & spend-by-tag** | Tag projects, see estimated cost grouped by tag (multi-tag projects count toward each; untagged bucket). On the Sessions tab. | `hooks/useTags.ts`, `organisms/TagBreakdown`, `molecules/TagEditor` |
| **Budget alerts + calendar periods** | The existing silent USD caps now warn at 70/90/100% (browser notification + optional chime, deduped per calendar window) and reset on real day/week/month boundaries honoring the week-start setting. | `lib/budget.ts`, `hooks/useBudgetAlerts.ts`, `molecules/SpendingLimits`, `useSettings.budgetAlert`, `SettingsView` |
| **Weekly burn-rate forecast** | Projects weekly-limit usage against the reset from live `seven_day` data (estimate fallback) — the cross-window analog to the 5h-block ETA. | `lib/forecast.ts`, `molecules/PlanUsage` |
| **Spend reports + rate-limit gauges** | On-demand CSV/JSON spend report (per-day + per-model + summary) on Trends; `PlanUsage` now surfaces all `seven_day_*` ceilings + the plan-tier label. | `lib/report.ts`, `TrendsTab`, `molecules/PlanUsage` |

## Design notes

- Persistence mirrors `useLimits`/`useSettings` (localStorage) — nothing is sent to the backend; no new outbound network calls. Spend reports are client-generated downloads; alerts are local notifications. Analytics events stay path-free.
- Scheduled *email* reports (a LiteLLM feature) were deliberately **excluded** — they'd leave the machine, violating the local-first model. Reports are on-demand instead.
- The app already reads *real billed* spend from a LiteLLM proxy (`server/scan.ts`); that's a separate, pre-existing integration.

## ⚠️ Stacked on #22

This branch is stacked on `fix/tooltip-and-week-start` (open in #22) — WS2/WS3 depend on the `lib/week.ts` calendar helpers added there. **Merge #22 first**, after which this PR's diff will reduce to just the four features above.

## Testing

- `npx tsc -b` clean; `npm run build` clean.
- Verified live in the browser: tagged 3 projects → grouped in the Spend-by-Tag donut; set caps → calendar-aligned cards with reset countdowns + threshold colors; spend-report CSV/JSON export; forced subscription mode to confirm the PlanUsage forecast/tier render path. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)