### PR TITLE
Live usage: 5xx-outage handling, Fable weekly bar, and a 'contributing to your limits' panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.14] - 2026-07-06
+
+### Added
+- Introduced a panel displaying limits usage breakdown on the Live tab.
+- Added per-model weekly bars in the Plan Usage view from the live limits API.
+
+### Changed
+- Enhanced UsageEvent with additional attribution data.
+- Improved contributor resolution logic for session cost calculations.
+- Derived per-model weekly bars utilizing the new limits structure.
+- Updated the method for handling non-OK responses from OAuth endpoints to provide accurate service outage messages.
+
+### Fixed
+- Addressed the handling of Anthropic 5xx outages for more reliable user messaging and retry logic.
+
 ## [0.1.13] - 2026-06-27
 
 ### Added
@@ -159,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.14]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.14
 [0.1.13]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.13
 [0.1.12]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.12
 [0.1.11]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/contributors.ts
+++ b/server/contributors.ts
@@ -1,0 +1,277 @@
+// "What's contributing to your limits usage?" — a local, cost-weighted replica of
+// the breakdown the Claude Code CLI shows under its usage view. Every figure is a
+// *share of estimated cost* (dollars, via pricing.ts), not a token or call count,
+// matching the CLI: `pct = round(behavior.cost / totalCost * 100)`, shown only when
+// pct >= SHOW_PCT. Two independent windows (Day = last 24h, Week = last 7d).
+//
+// Thresholds are taken verbatim from the CLI: context > 150k, 4+ parallel sessions,
+// sessions active 8+ hours, >=10% to surface. A few attributions are necessarily
+// approximated from local transcripts (noted inline) since the CLI's per-request
+// attribution tags aren't recoverable from the logs on disk.
+
+import type { UsageEvent } from './scan.ts';
+import type { InsightsData } from './insights-scan.ts';
+import { estimateCost } from './pricing.ts';
+
+const DAY_MS = 24 * 3600_000;
+const WEEK_MS = 7 * DAY_MS;
+
+const SHOW_PCT = 10; // CLI: hlr / A4o — a behavior surfaces only at >=10% of cost
+const CTX_THRESHOLD = 150_000; // CLI: b8f — ">150k context"
+const PARALLEL_MIN = 4; // CLI: m5l — "4+ sessions ran in parallel"
+const CRON_MS = 8 * 3600_000; // CLI: sessions "active for 8+ hours"
+const TOP_N = 8; // rows kept per breakdown table
+
+export interface ContribBehavior {
+  key: 'long_context' | 'subagent_heavy' | 'high_parallel' | 'cron';
+  headline: string;
+  body: string;
+  pct: number;
+}
+export interface ContribRow {
+  name: string;
+  pct: number;
+}
+export interface ContribWindow {
+  totalCost: number;
+  requestCount: number;
+  sessionCount: number;
+  behaviors: ContribBehavior[];
+  subagents: ContribRow[];
+  mcpServers: ContribRow[];
+  skills: ContribRow[];
+  plugins: ContribRow[];
+}
+export interface ContributorsData {
+  day: ContribWindow;
+  week: ContribWindow;
+}
+
+const BEHAVIOR_BODY: Record<ContribBehavior['key'], string> = {
+  long_context:
+    'Longer sessions are more expensive even when cached. /compact mid-task, /clear when switching to new tasks.',
+  subagent_heavy:
+    'Each subagent runs its own requests. Be deliberate about spawning them — and consider configuring a cheaper model for simpler subagents.',
+  high_parallel:
+    "All sessions share one limit. If you don't need them all at once, queueing uses it more evenly.",
+  cron:
+    'These are often background/loop sessions. Continuous usage can add up quickly so make sure it is intentional.',
+};
+
+function headlineFor(key: ContribBehavior['key'], pct: number): string {
+  switch (key) {
+    case 'long_context':
+      return `${pct}% of your usage was at >150k context`;
+    case 'subagent_heavy':
+      return `${pct}% of your usage came from subagent-heavy sessions`;
+    case 'high_parallel':
+      return `${pct}% of your usage was while 4+ sessions ran in parallel`;
+    case 'cron':
+      return `${pct}% of your usage came from sessions active for 8+ hours`;
+  }
+}
+
+/** `mcp__<server>__<tool>` → `<server>` (null for non-MCP tools). */
+function mcpServerOf(toolName: string): string | null {
+  if (!toolName.startsWith('mcp__')) return null;
+  const rest = toolName.slice(5);
+  const server = rest.split('__')[0];
+  return server || null;
+}
+
+/** Map → sorted [{name, pct}] (desc, pct>0), mirroring the CLI's flr(). */
+function toRows(map: Map<string, number>, total: number): ContribRow[] {
+  if (total <= 0) return [];
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, cost]) => ({ name, pct: Math.round((cost / total) * 100) }))
+    .filter((r) => r.pct > 0)
+    .slice(0, TOP_N);
+}
+
+function addTo(map: Map<string, number>, key: string, cost: number): void {
+  if (!key) return;
+  map.set(key, (map.get(key) ?? 0) + cost);
+}
+
+/** Active-session count at any ts, from top-level session intervals (sweep line). */
+function makeConcurrency(intervals: Array<[number, number]>): (ts: number) => number {
+  const bounds: Array<[number, number]> = [];
+  for (const [start, end] of intervals) {
+    bounds.push([start, 1]);
+    bounds.push([end, -1]);
+  }
+  bounds.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const times: number[] = [];
+  const counts: number[] = [];
+  let cur = 0;
+  for (const [t, d] of bounds) {
+    cur += d;
+    times.push(t);
+    counts.push(cur);
+  }
+  return (ts: number): number => {
+    // last boundary with time <= ts
+    let lo = 0;
+    let hi = times.length - 1;
+    let idx = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (times[mid] <= ts) {
+        idx = mid;
+        lo = mid + 1;
+      } else hi = mid - 1;
+    }
+    return idx >= 0 ? counts[idx] : 0;
+  };
+}
+
+function buildWindow(
+  events: UsageEvent[],
+  topLevelOf: (sessionId: string) => string,
+  isHeavyTop: (topLevelId: string) => boolean,
+  subagentTypeOf: (sessionId: string) => string,
+): ContribWindow {
+  // Per top-level session group: cost, first/last ts (for cron 8h + parallel).
+  const topDur = new Map<string, { first: number; last: number }>();
+  for (const e of events) {
+    const tl = topLevelOf(e.sessionId);
+    const d = topDur.get(tl);
+    if (d) {
+      if (e.ts < d.first) d.first = e.ts;
+      if (e.ts > d.last) d.last = e.ts;
+    } else topDur.set(tl, { first: e.ts, last: e.ts });
+  }
+  const activeAt = makeConcurrency([...topDur.values()].map((d) => [d.first, d.last]));
+
+  let totalCost = 0;
+  let longCtx = 0;
+  let subagentHeavy = 0;
+  let highParallel = 0;
+  let cron = 0;
+
+  const byMcp = new Map<string, number>();
+  const bySubagent = new Map<string, number>();
+  const bySkill = new Map<string, number>();
+  const byPlugin = new Map<string, number>();
+  const sessions = new Set<string>();
+
+  for (const e of events) {
+    const cost = estimateCost(e.model, e);
+    if (cost <= 0) continue;
+    totalCost += cost;
+    const tl = topLevelOf(e.sessionId);
+    sessions.add(tl);
+
+    // Behaviors (each an independent characteristic — shares can overlap). These
+    // are attributed at the *top-level session* grain: a session that spawned
+    // subagents counts its whole cost (orchestrator + children) as subagent-heavy,
+    // and a long-running orchestrator's whole cost counts as cron.
+    const contextTokens = e.inputTokens + e.cacheReadTokens + e.cacheCreateTokens;
+    if (contextTokens > CTX_THRESHOLD) longCtx += cost;
+    if (isHeavyTop(tl)) subagentHeavy += cost;
+    if (activeAt(e.ts) >= PARALLEL_MIN) highParallel += cost;
+    const dur = topDur.get(tl);
+    if (dur && dur.last - dur.first >= CRON_MS) cron += cost;
+
+    // Breakdowns.
+    const seenServers = new Set<string>();
+    for (const t of e.tools) {
+      const server = mcpServerOf(t);
+      if (server && !seenServers.has(server)) {
+        seenServers.add(server);
+        addTo(byMcp, server, cost);
+      }
+    }
+    if (e.isSidechain) addTo(bySubagent, subagentTypeOf(e.sessionId), cost);
+    for (const skill of e.skills) {
+      addTo(bySkill, skill, cost);
+      const sep = skill.indexOf(':');
+      if (sep > 0) addTo(byPlugin, skill.slice(0, sep), cost); // `plugin:skill`
+    }
+  }
+
+  const behaviors: ContribBehavior[] = (
+    [
+      ['long_context', longCtx],
+      ['subagent_heavy', subagentHeavy],
+      ['high_parallel', highParallel],
+      ['cron', cron],
+    ] as Array<[ContribBehavior['key'], number]>
+  )
+    .map(([key, cost]) => ({
+      key,
+      pct: totalCost > 0 ? Math.round((cost / totalCost) * 100) : 0,
+    }))
+    .filter((b) => b.pct >= SHOW_PCT)
+    .sort((a, b) => b.pct - a.pct)
+    .map((b) => ({ key: b.key, pct: b.pct, headline: headlineFor(b.key, b.pct), body: BEHAVIOR_BODY[b.key] }));
+
+  return {
+    totalCost,
+    requestCount: events.length,
+    sessionCount: sessions.size,
+    behaviors,
+    subagents: toRows(bySubagent, totalCost),
+    mcpServers: toRows(byMcp, totalCost),
+    skills: toRows(bySkill, totalCost),
+    plugins: toRows(byPlugin, totalCost),
+  };
+}
+
+export function buildContributors(
+  events: UsageEvent[],
+  insights: InsightsData,
+  now: number,
+): ContributorsData {
+  // agentId → subagent type (from Task spawns), then sessionId → type via session meta.
+  const typeByAgentId = new Map<string, string>();
+  for (const spawn of insights.taskSpawns) {
+    if (spawn.agentIdFromResult && spawn.subagentType) {
+      typeByAgentId.set(spawn.agentIdFromResult, spawn.subagentType);
+    }
+  }
+  const agentIdToSession = new Map<string, string>();
+  const typeBySession = new Map<string, string>();
+  for (const [sid, meta] of insights.sessionsMeta) {
+    if (meta.agentId) {
+      agentIdToSession.set(meta.agentId, sid);
+      if (typeByAgentId.has(meta.agentId)) typeBySession.set(sid, typeByAgentId.get(meta.agentId)!);
+    }
+  }
+  const subagentTypeOf = (sessionId: string): string => typeBySession.get(sessionId) ?? 'unknown';
+
+  // Session graph: a Task spawn ties a child (subagent) session to its parent, so a
+  // sidechain session resolves up to the top-level session that ultimately launched it.
+  const parentOf = new Map<string, string>();
+  for (const spawn of insights.taskSpawns) {
+    const childSid = spawn.agentIdFromResult ? agentIdToSession.get(spawn.agentIdFromResult) : undefined;
+    if (childSid && spawn.sessionId && childSid !== spawn.sessionId) parentOf.set(childSid, spawn.sessionId);
+  }
+  const topLevelOf = (sessionId: string): string => {
+    let cur = sessionId;
+    const guard = new Set<string>();
+    while (parentOf.has(cur) && !guard.has(cur)) {
+      guard.add(cur);
+      cur = parentOf.get(cur)!;
+    }
+    return cur;
+  };
+
+  // A top-level session is "subagent-heavy" if it spawned any subagent — either it
+  // is a parent in the graph, or its session meta records subagent spawns.
+  const heavyTop = new Set<string>();
+  for (const parentSid of parentOf.values()) heavyTop.add(topLevelOf(parentSid));
+  for (const [sid, meta] of insights.sessionsMeta) {
+    if (meta.subagentSpawns > 0) heavyTop.add(topLevelOf(sid));
+  }
+  const isHeavyTop = (topLevelId: string): boolean => heavyTop.has(topLevelId);
+
+  const buildFor = (windowMs: number): ContribWindow => {
+    const from = now - windowMs;
+    const windowEvents = events.filter((e) => e.ts >= from && e.ts <= now);
+    return buildWindow(windowEvents, topLevelOf, isHeavyTop, subagentTypeOf);
+  };
+
+  return { day: buildFor(DAY_MS), week: buildFor(WEEK_MS) };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import {
   buildErrors, buildRetries, buildLanguages, buildBranches, buildMcp,
   buildComplexity, buildYield, buildRejections, buildSubagentStats, buildFileChurn, scopeInsights,
 } from './insights.ts';
+import { buildContributors } from './contributors.ts';
 import { getCommandUsage } from './history.ts';
 import { getWorkspaceTasks, getInventory } from './workspace.ts';
 import { getLiveSubagents } from './subagents-live.ts';
@@ -346,6 +347,26 @@ app.get('/api/usage/models', async (req, res) => {
     const source = parseSource(req.query.source);
     const data = memoBuilder('models', [days, source], eventsFingerprint(), () =>
       buildModels(filterSource(events, source), computedAt, days),
+    );
+    res.json(wrap(data, computedAt));
+  } catch (e) {
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// "What's contributing to your limits usage?" — cost-weighted Day/Week breakdown,
+// replicating the Claude CLI panel. Joins priced events (cost/context) with insights
+// (session duration + subagent type). Both windows are returned in one payload.
+app.get('/api/usage/contributors', async (req, res) => {
+  try {
+    const { events, computedAt } = await getEvents();
+    const { insights } = await getInsights();
+    const source = parseSource(req.query.source);
+    const data = memoBuilder(
+      'contributors',
+      [source, insightsFingerprint()],
+      eventsFingerprint(),
+      () => buildContributors(filterSource(events, source), scopeInsights(insights, source), computedAt),
     );
     res.json(wrap(data, computedAt));
   } catch (e) {

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -4,6 +4,8 @@ import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
 
+const CLAUDE_CODE_UA = 'claude-code/2.1.199'; // keep roughly in step with the CLI
+
 export type UsageSource = 'code' | 'cowork';
 
 export interface UsageEvent {
@@ -325,9 +327,26 @@ export function oauthHeaders(accessToken: string): Record<string, string> {
   return {
     'Authorization': `Bearer ${accessToken}`,
     'anthropic-beta': 'oauth-2025-04-20',
-    'User-Agent': 'claude-code/2.1.162',
+    'User-Agent': CLAUDE_CODE_UA,
     'Accept': 'application/json',
   };
+}
+
+/**
+ * GET an Anthropic OAuth endpoint, retrying transient 5xx with short backoff.
+ * 4xx (incl. 403 / 429) return immediately — retrying auth failures or rate
+ * limits only makes things worse.
+ */
+async function oauthGet(url: string, accessToken: string): Promise<Response> {
+  const headers = oauthHeaders(accessToken);
+  const backoffs = [250, 750]; // ms → 3 attempts total
+  let res = await fetch(url, { headers });
+  for (const wait of backoffs) {
+    if (res.status < 500) return res;
+    await new Promise((r) => setTimeout(r, wait));
+    res = await fetch(url, { headers });
+  }
+  return res;
 }
 
 export async function fetchLiveUsage(): Promise<any> {
@@ -346,9 +365,7 @@ export async function fetchLiveUsage(): Promise<any> {
   }
 
   const url = 'https://api.anthropic.com/api/oauth/usage';
-  const headers = oauthHeaders(credentials.claudeAiOauth.accessToken);
-
-  const res = await fetch(url, { headers });
+  const res = await oauthGet(url, credentials.claudeAiOauth.accessToken);
   if (res.status === 403) {
     throw new Error('OAuth token invalid (403). Please run any command in Claude CLI to refresh.');
   }
@@ -386,9 +403,7 @@ export async function fetchLiveProfile(): Promise<any> {
     throw new Error('OAuth token expired');
   }
 
-  const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
-    headers: oauthHeaders(accessToken),
-  });
+  const res = await oauthGet('https://api.anthropic.com/api/oauth/profile', accessToken);
   if (!res.ok) {
     throw new Error(`Failed to fetch profile from Anthropic API: ${res.status} ${res.statusText}`);
   }

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -17,6 +17,8 @@ export interface UsageEvent {
   cacheCreateTokens: number;
   cacheReadTokens: number;
   tools: string[]; // tool_use names invoked in this assistant message
+  skills: string[]; // Skill tool_use names invoked in this message (for cost attribution)
+  isSidechain: boolean; // true when this message is a subagent (Task) sub-response
   projectPath: string; // decoded path of the project directory
   gitBranch: string; // git branch at the time of the message ('' if unknown)
   source: UsageSource; // 'code' = Claude Code CLI, 'cowork' = desktop local-agent mode
@@ -155,6 +157,9 @@ async function parseFile(
       }
     }
   } catch { /* keep empty */ }
+  // A file under a `subagents/` segment is a subagent (Task) transcript — mirrors
+  // insights-scan's isSubagentFile(). Used to attribute cost to subagent usage.
+  const fileIsSidechain = /(^|[\\/])subagents([\\/])/.test(file);
   const rl = createInterface({
     input: createReadStream(file, { encoding: 'utf8' }),
     crlfDelay: Infinity,
@@ -177,10 +182,18 @@ async function parseFile(
     if (Number.isNaN(ts)) continue;
 
     const tools: string[] = [];
+    const skills: string[] = [];
     const content = obj.message?.content;
     if (Array.isArray(content)) {
       for (const block of content) {
-        if (block?.type === 'tool_use' && typeof block.name === 'string') tools.push(block.name);
+        if (block?.type === 'tool_use' && typeof block.name === 'string') {
+          tools.push(block.name);
+          // A Skill invocation names the skill in its input — capture for attribution.
+          if (block.name === 'Skill') {
+            const s = block.input?.skill ?? block.input?.command ?? block.input?.name;
+            if (typeof s === 'string' && s) skills.push(s);
+          }
+        }
       }
     }
 
@@ -199,6 +212,8 @@ async function parseFile(
       cacheCreateTokens: num(usage.cache_creation_input_tokens),
       cacheReadTokens: num(usage.cache_read_input_tokens),
       tools,
+      skills,
+      isSidechain: fileIsSidechain || obj.isSidechain === true,
       projectPath: resolvedProjectPath,
       gitBranch,
       source,

--- a/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
+++ b/src/components/design-system/molecules/PlanUsage/PlanUsage.tsx
@@ -11,6 +11,16 @@ const WEEK_MS = 7 * 24 * 3600_000;
 const DEFAULT_BLOCK_LIMIT = 6000000; // 6.0M effective tokens
 const DEFAULT_WEEKLY_LIMIT = 35000000; // 35M effective tokens
 
+// Per-model weekly bar (normalized across the new limits[] array and legacy keys).
+type WeeklyModelBar = { label: string; pct: number; resetsAt: string | null; color: string };
+const MODEL_COLORS: Record<string, string> = {
+  Opus: '#a78bfa',
+  Sonnet: '#10b981',
+  Haiku: '#f472b6',
+  Fable: '#f59e0b',
+};
+const DEFAULT_MODEL_COLOR = '#22d3ee';
+
 export function PlanUsage({ block, weekly, liveUsage, weekStart, tier }: PlanUsageProps) {
   const [, forceUpdate] = useState(0);
 
@@ -61,14 +71,31 @@ export function PlanUsage({ block, weekly, liveUsage, weekStart, tier }: PlanUsa
     ? null
     : buildWeeklyForecast({ pct: weeklyPctRaw, windowStart: weeklyWindowStart, resetsAt: weeklyResetsAt, now });
 
-  // Model-specific weekly limits — only present on some plans (e.g. Max exposes a Sonnet cap).
-  const modelLimits = hasLive
-    ? ([
-        { label: 'Weekly · Sonnet', info: liveUsage.seven_day_sonnet, color: '#10b981' },
-        { label: 'Weekly · Opus', info: liveUsage.seven_day_opus, color: '#a78bfa' },
-        { label: 'Weekly · Cowork', info: liveUsage.seven_day_cowork, color: '#22d3ee' },
-      ] as const).filter((l) => l.info != null)
+  // Model-specific weekly limits — only present on some plans (e.g. Max exposes a
+  // Sonnet/Opus cap; newer accounts expose Fable). Anthropic's current API delivers
+  // these as `limits[]` entries with kind 'weekly_scoped' (the top-level
+  // seven_day_<model> keys are being phased out → all null). Prefer the array;
+  // fall back to the legacy keys for older responses.
+  const scopedFromLimits: WeeklyModelBar[] = hasLive
+    ? (liveUsage.limits ?? [])
+        .filter((l) => l.group === 'weekly' && l.kind === 'weekly_scoped' && l.scope?.model?.display_name)
+        .map((l) => {
+          const name = l.scope!.model!.display_name!;
+          return { label: `Weekly · ${name}`, pct: Math.round(l.percent), resetsAt: l.resets_at, color: MODEL_COLORS[name] ?? DEFAULT_MODEL_COLOR };
+        })
     : [];
+
+  const legacyModelLimits: WeeklyModelBar[] = hasLive
+    ? ([
+        { label: 'Weekly · Sonnet', info: liveUsage.seven_day_sonnet, color: MODEL_COLORS.Sonnet },
+        { label: 'Weekly · Opus', info: liveUsage.seven_day_opus, color: MODEL_COLORS.Opus },
+        { label: 'Weekly · Cowork', info: liveUsage.seven_day_cowork, color: DEFAULT_MODEL_COLOR },
+      ] as const)
+        .filter((l) => l.info != null)
+        .map((l) => ({ label: l.label, pct: Math.round(l.info!.utilization), resetsAt: l.info!.resets_at, color: l.color }))
+    : [];
+
+  const modelLimits: WeeklyModelBar[] = scopedFromLimits.length ? scopedFromLimits : legacyModelLimits;
 
   const tierLabel = tier ? tier.replace(/_/g, ' ').toUpperCase() : null;
 
@@ -118,12 +145,11 @@ export function PlanUsage({ block, weekly, liveUsage, weekStart, tier }: PlanUsa
         </div>
 
         {/* Per-model weekly limits (shown only when the live API reports them) */}
-        {modelLimits.map(({ label, info, color }) => {
-          const pct = Math.round(info!.utilization);
-          const resetsAt = Date.parse(info!.resets_at);
-          const resetStr = info!.resets_at == null
+        {modelLimits.map(({ label, pct, resetsAt, color }) => {
+          const parsed = resetsAt ? Date.parse(resetsAt) : NaN;
+          const resetStr = resetsAt == null
             ? 'on next msg'
-            : formatRemainingDays(Math.max(0, (isNaN(resetsAt) ? now : resetsAt) - now));
+            : formatRemainingDays(Math.max(0, (isNaN(parsed) ? now : parsed) - now));
           return (
             <div key={label} className="space-y-1.5">
               <div className="flex justify-between items-center text-xs">

--- a/src/components/design-system/organisms/LimitsContributors/LimitsContributors.tsx
+++ b/src/components/design-system/organisms/LimitsContributors/LimitsContributors.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { Section } from '@/components/design-system/molecules/Section/Section';
+import { ToggleGroup } from '@/components/design-system/atoms/ToggleGroup/ToggleGroup';
+import { ProgressBar } from '@/components/design-system/atoms/ProgressBar/ProgressBar';
+import { usePolling } from '@/hooks/usePolling';
+import { useSource } from '@/hooks/useSource';
+import type { ContribRow, ContribWindow, ContributorsData } from '@/types';
+
+type WindowKey = 'day' | 'week';
+
+const RANGE_OPTIONS: { value: WindowKey; label: string }[] = [
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+];
+
+const BREAKDOWNS: { key: keyof Pick<ContribWindow, 'skills' | 'subagents' | 'plugins' | 'mcpServers'>; label: string; color: string }[] = [
+  { key: 'skills', label: 'Skills', color: '#f59e0b' },
+  { key: 'subagents', label: 'Subagents', color: '#a78bfa' },
+  { key: 'plugins', label: 'Plugins', color: '#22d3ee' },
+  { key: 'mcpServers', label: 'MCP servers', color: '#10b981' },
+];
+
+function BreakdownTable({ label, rows, color }: { label: string; rows: ContribRow[]; color: string }) {
+  if (!rows.length) return null;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-wider text-zinc-500">
+        <span>{label}</span>
+        <span>% of usage</span>
+      </div>
+      <div className="space-y-1.5">
+        {rows.map((r) => (
+          <div key={r.name} className="space-y-1">
+            <div className="flex items-center justify-between text-xs">
+              <span className="truncate pr-2 text-zinc-300">{r.name}</span>
+              <span className="font-mono tabular-nums text-zinc-400">{r.pct}%</span>
+            </div>
+            <ProgressBar pct={r.pct} color={color} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function LimitsContributors() {
+  const { withSrc } = useSource();
+  const { data } = usePolling<ContributorsData>(withSrc('/api/usage/contributors'), 60000);
+  const [range, setRange] = useState<WindowKey>('day');
+
+  if (!data) return null;
+  const win = data[range];
+
+  const hasBreakdowns = BREAKDOWNS.some(({ key }) => win[key].length > 0);
+  // Nothing worth showing in either window → hide the whole panel.
+  const dayEmpty = !data.day.behaviors.length && !BREAKDOWNS.some(({ key }) => data.day[key].length);
+  const weekEmpty = !data.week.behaviors.length && !BREAKDOWNS.some(({ key }) => data.week[key].length);
+  if (dayEmpty && weekEmpty) return null;
+
+  return (
+    <Section
+      title="What's contributing to your limits usage?"
+      help="Approximate, cost-weighted breakdown computed from local sessions on this machine — does not include other devices or claude.ai. These are independent characteristics of your usage, not a breakdown. Mirrors the Claude Code CLI usage view."
+      right={<ToggleGroup options={RANGE_OPTIONS} value={range} onChange={setRange} />}
+    >
+      <p className="mb-4 text-[11px] text-zinc-500">
+        {range === 'day' ? 'Last 24h' : 'Last 7d'} · approximate, based on local sessions on this machine
+      </p>
+
+      {/* Headline behaviors */}
+      {win.behaviors.length ? (
+        <div className="space-y-3">
+          {win.behaviors.map((b) => (
+            <div key={b.key} className="flex gap-2">
+              <span className="mt-0.5 select-none text-clay-400">↗</span>
+              <div>
+                <p className="text-sm font-semibold text-zinc-200">{b.headline}</p>
+                <p className="text-xs text-zinc-500">{b.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-zinc-500">Nothing over 10% in this period.</p>
+      )}
+
+      {/* Breakdown tables */}
+      {hasBreakdowns && (
+        <div className="mt-5 grid grid-cols-1 gap-5 border-t border-white/5 pt-5 sm:grid-cols-2">
+          {BREAKDOWNS.map(({ key, label, color }) => (
+            <BreakdownTable key={key} label={label} rows={win[key]} color={color} />
+          ))}
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/src/components/tabs/LiveTab/LiveTab.tsx
+++ b/src/components/tabs/LiveTab/LiveTab.tsx
@@ -2,6 +2,7 @@ import { BlockGauge } from '@/components/design-system/organisms/BlockGauge/Bloc
 import { UsageBarChart } from '@/components/design-system/organisms/UsageBarChart/UsageBarChart';
 import { Section } from '@/components/design-system/molecules/Section/Section';
 import { PlanUsage } from '@/components/design-system/molecules/PlanUsage/PlanUsage';
+import { LimitsContributors } from '@/components/design-system/organisms/LimitsContributors/LimitsContributors';
 import { SpendingLimits } from '@/components/design-system/molecules/SpendingLimits/SpendingLimits';
 import { GaugeSkeleton, ChartSkeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import { hourLabel } from '@/lib/format';
@@ -89,6 +90,9 @@ export function LiveTab({ limits }: LiveTabProps) {
           tier={configData.subscriptionType ?? configData.rateLimitTier ?? null}
         />
       )}
+
+      {/* What's contributing to your limits usage? — cost-weighted Day/Week breakdown. */}
+      {configData && !isApi && <LimitsContributors />}
 
       {/* Spend vs caps — always shown in API mode (the cost IS the bill);
           in subscription mode only when the user has configured caps. */}

--- a/src/hooks/useDashboardNotifications.ts
+++ b/src/hooks/useDashboardNotifications.ts
@@ -62,12 +62,19 @@ export function useDashboardNotifications(activeTab: string, limits: Limits) {
     }
     const lc = err.toLowerCase();
     const expired = lc.includes('expired') || lc.includes('no access token');
+    // Upstream Anthropic outage (5xx) — not a token problem; running `claude` won't help.
+    const upstream = /:\s*5\d\d\b/.test(err) || lc.includes('service unavailable')
+      || lc.includes('bad gateway') || lc.includes('gateway timeout');
     notify({
       id: 'offline',
       severity: 'warning',
-      title: expired ? 'Claude.ai session expired' : 'Claude.ai connection offline',
+      title: expired ? 'Claude.ai session expired'
+        : upstream ? 'Claude.ai service unavailable'
+        : 'Claude.ai connection offline',
       message: expired
         ? 'Token needs a refresh — run `claude` in your terminal and it refreshes automatically.'
+        : upstream
+        ? `Anthropic's usage service is temporarily unavailable (${err.match(/5\d\d/)?.[0] ?? '5xx'}). It's on their side — the dashboard keeps retrying and this clears on its own.`
         : `${err} — try running \`claude\` in a terminal.`,
     });
   }, [isApi, liveUsage.data?.error, notify, dismiss]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,34 @@ export interface LiveUsageData {
   seven_day_sonnet?: LiveLimitInfo | null;
   seven_day_cowork?: LiveLimitInfo | null;
   seven_day_omelette?: LiveLimitInfo | null;
+  limits?: LiveLimit[] | null;
   error?: string;
+}
+
+// "What's contributing to your limits usage?" — cost-weighted Day/Week breakdown.
+export interface ContribBehavior {
+  key: 'long_context' | 'subagent_heavy' | 'high_parallel' | 'cron';
+  headline: string;
+  body: string;
+  pct: number;
+}
+export interface ContribRow {
+  name: string;
+  pct: number;
+}
+export interface ContribWindow {
+  totalCost: number;
+  requestCount: number;
+  sessionCount: number;
+  behaviors: ContribBehavior[];
+  subagents: ContribRow[];
+  mcpServers: ContribRow[];
+  skills: ContribRow[];
+  plugins: ContribRow[];
+}
+export interface ContributorsData {
+  day: ContribWindow;
+  week: ContribWindow;
 }
 
 export interface HeatmapData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,22 @@ export interface LiveLimitInfo {
   resets_at: string;
 }
 
+/**
+ * One entry in Anthropic's newer `limits` array — the model-scoped source that
+ * replaced the top-level `seven_day_<model>` keys. `kind` is 'session' |
+ * 'weekly_all' | 'weekly_scoped'; scoped weekly windows (e.g. Fable) carry the
+ * model in `scope.model.display_name`.
+ */
+export interface LiveLimit {
+  kind: string;
+  group: string; // 'session' | 'weekly'
+  percent: number;
+  severity: string;
+  resets_at: string | null;
+  scope: { model?: { id: string | null; display_name: string | null } | null; surface?: string | null } | null;
+  is_active: boolean;
+}
+
 export interface LiveUsageData {
   five_hour: LiveLimitInfo;
   seven_day: LiveLimitInfo;


### PR DESCRIPTION
Three related improvements to the Live tab, split into one commit each.

## 1. `fix(live-usage)` — honest handling of Anthropic 5xx outages
The OAuth `usage`/`profile` endpoints can return **503** during upstream outages. Any non-OK response used to surface as *"connection offline — try running `claude` in a terminal"*, advice that only helps an expired token and misleads for a service outage.

- `scan.ts`: new `oauthGet()` retries transient **5xx** with short backoff (250/750 ms); **4xx incl. 403/429 return immediately** so auth failures and rate limits aren't hammered. `fetchLiveUsage`/`fetchLiveProfile` route through it.
- `scan.ts`: bump the hardcoded User-Agent to `claude-code/2.1.199`.
- `useDashboardNotifications`: classify upstream 5xx separately → *"Claude.ai service unavailable — it's on their side, the dashboard keeps retrying."*

## 2. `feat(plan-usage)` — per-model weekly bars from the live `limits[]` API
Anthropic migrated per-model weekly windows off the top-level `seven_day_<model>` keys (now `null`) to a structured **`limits[]`** array whose `weekly_scoped` entries carry `scope.model.display_name` — including the new **Fable** model.

- `types.ts`: `LiveLimit` shape + `limits[]` on `LiveUsageData`.
- `PlanUsage`: derive per-model bars from `limits[]` (`kind === 'weekly_scoped'`), keyed by `display_name` with a model→colour map (Opus/Sonnet/Haiku/Fable), falling back to the legacy `seven_day_*` keys. Any scoped model Anthropic exposes now renders automatically.

## 3. `feat(live)` — "What's contributing to your limits usage?" panel
A local, **cost-weighted** replica of the breakdown the Claude Code CLI shows under its usage view, rendered under Plan Usage with a **Day/Week** toggle. Every figure is a share of estimated cost (`pricing.ts`): `pct = round(cost/totalCost*100)`, surfaced only at **≥10%**. Thresholds mirror the CLI verbatim: context **>150k**, **4+** parallel sessions, sessions active **8h+**.

- `scan.ts`: enrich `UsageEvent` with `isSidechain` (path-based) + `skills[]` (from `Skill` tool_use).
- `contributors.ts`: `buildContributors()` — resolves subagent sub-sessions to their **top-level session** (an orchestrator that spawned agents counts its whole cost), computing the four behaviours + subagent/MCP/skill/plugin breakdowns over Day (24h) and Week (7d).
- `index.ts`: `GET /api/usage/contributors`, joining priced events with insights (session graph + duration), source-aware and memoised.
- `types.ts` + `LimitsContributors`: frontend shapes and panel.

**Attribution caveats** (best-effort from local transcripts): subagent types that can't be resolved from Task results show as `unknown`; skill cost is attributed to the invoking request.

## Verification
- `npx tsc -b` clean.
- Built in Docker (`npm run docker:up`) and verified in a real browser: the Fable weekly bar renders (5% · resets 7d) and the contributors panel renders both windows with a working Day/Week toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)