### PR TITLE
fix(contributors): match Claude by reading the CLI's own attribution tags

### DIFF
--- a/server/contributors.ts
+++ b/server/contributors.ts
@@ -1,29 +1,32 @@
 // "What's contributing to your limits usage?" — a local, cost-weighted replica of
 // the breakdown the Claude Code CLI shows under its usage view. Every figure is a
 // *share of estimated cost* (dollars, via pricing.ts), not a token or call count,
-// matching the CLI: `pct = round(behavior.cost / totalCost * 100)`, shown only when
+// matching the CLI: `pct = round(behaviour.cost / totalCost * 100)`, shown only when
 // pct >= SHOW_PCT. Two independent windows (Day = last 24h, Week = last 7d).
 //
-// Thresholds are taken verbatim from the CLI: context > 150k, 4+ parallel sessions,
-// sessions active 8+ hours, >=10% to surface. A few attributions are necessarily
-// approximated from local transcripts (noted inline) since the CLI's per-request
-// attribution tags aren't recoverable from the logs on disk.
+// Attribution comes from the CLI's OWN per-request tags — `attributionAgent`,
+// `attributionSkill`, `attributionMcpServer`, `attributionPlugin` — which Claude Code
+// writes onto every assistant message and its usage view reads back. Using them
+// (rather than reconstructing from tool names / session graphs) is what makes the
+// subagent, skill and MCP breakdowns match Claude exactly, including the CLI's rule
+// that an MCP server's cost covers the whole session tail once its results are in
+// context. Context (>150k), 8h-session and 4+-parallel thresholds are the CLI's.
 
 import type { UsageEvent } from './scan.ts';
-import type { InsightsData } from './insights-scan.ts';
 import { estimateCost } from './pricing.ts';
 
 const DAY_MS = 24 * 3600_000;
 const WEEK_MS = 7 * DAY_MS;
 
-const SHOW_PCT = 10; // CLI: hlr / A4o — a behavior surfaces only at >=10% of cost
+const SHOW_PCT = 10; // CLI: hlr / A4o — an insight surfaces only at >=10% of cost
 const CTX_THRESHOLD = 150_000; // CLI: b8f — ">150k context"
 const PARALLEL_MIN = 4; // CLI: m5l — "4+ sessions ran in parallel"
 const CRON_MS = 8 * 3600_000; // CLI: sessions "active for 8+ hours"
 const TOP_N = 8; // rows kept per breakdown table
+const MAX_INSIGHTS = 6; // headline lines kept (behaviours + entities), like the CLI
 
 export interface ContribBehavior {
-  key: 'long_context' | 'subagent_heavy' | 'high_parallel' | 'cron';
+  key: string;
   headline: string;
   body: string;
   pct: number;
@@ -47,37 +50,8 @@ export interface ContributorsData {
   week: ContribWindow;
 }
 
-const BEHAVIOR_BODY: Record<ContribBehavior['key'], string> = {
-  long_context:
-    'Longer sessions are more expensive even when cached. /compact mid-task, /clear when switching to new tasks.',
-  subagent_heavy:
-    'Each subagent runs its own requests. Be deliberate about spawning them — and consider configuring a cheaper model for simpler subagents.',
-  high_parallel:
-    "All sessions share one limit. If you don't need them all at once, queueing uses it more evenly.",
-  cron:
-    'These are often background/loop sessions. Continuous usage can add up quickly so make sure it is intentional.',
-};
-
-function headlineFor(key: ContribBehavior['key'], pct: number): string {
-  switch (key) {
-    case 'long_context':
-      return `${pct}% of your usage was at >150k context`;
-    case 'subagent_heavy':
-      return `${pct}% of your usage came from subagent-heavy sessions`;
-    case 'high_parallel':
-      return `${pct}% of your usage was while 4+ sessions ran in parallel`;
-    case 'cron':
-      return `${pct}% of your usage came from sessions active for 8+ hours`;
-  }
-}
-
-/** `mcp__<server>__<tool>` → `<server>` (null for non-MCP tools). */
-function mcpServerOf(toolName: string): string | null {
-  if (!toolName.startsWith('mcp__')) return null;
-  const rest = toolName.slice(5);
-  const server = rest.split('__')[0];
-  return server || null;
-}
+const MCP_BODY =
+  'MCP tool results stay in context for the rest of the session. /compact to flush them, or disable servers you don’t need.';
 
 /** Map → sorted [{name, pct}] (desc, pct>0), mirroring the CLI's flr(). */
 function toRows(map: Map<string, number>, total: number): ContribRow[] {
@@ -94,7 +68,7 @@ function addTo(map: Map<string, number>, key: string, cost: number): void {
   map.set(key, (map.get(key) ?? 0) + cost);
 }
 
-/** Active-session count at any ts, from top-level session intervals (sweep line). */
+/** Active top-level-session count at any ts (sweep line over session intervals). */
 function makeConcurrency(intervals: Array<[number, number]>): (ts: number) => number {
   const bounds: Array<[number, number]> = [];
   for (const [start, end] of intervals) {
@@ -111,7 +85,6 @@ function makeConcurrency(intervals: Array<[number, number]>): (ts: number) => nu
     counts.push(cur);
   }
   return (ts: number): number => {
-    // last boundary with time <= ts
     let lo = 0;
     let hi = times.length - 1;
     let idx = -1;
@@ -126,23 +99,30 @@ function makeConcurrency(intervals: Array<[number, number]>): (ts: number) => nu
   };
 }
 
-function buildWindow(
-  events: UsageEvent[],
-  topLevelOf: (sessionId: string) => string,
-  isHeavyTop: (topLevelId: string) => boolean,
-  subagentTypeOf: (sessionId: string) => string,
-): ContribWindow {
-  // Per top-level session group: cost, first/last ts (for cron 8h + parallel).
-  const topDur = new Map<string, { first: number; last: number }>();
+function buildWindow(events: UsageEvent[]): ContribWindow {
+  // Per-session first/last ts + whether it is a top-level (non-subagent) session.
+  // Subagent sub-sessions are excluded from the "parallel" / "8h" behaviours: a
+  // workflow fanning out 16 agents isn't "16 sessions in parallel", and a subagent's
+  // own transcript is short-lived. Top-level = has at least one non-sidechain message.
+  const sess = new Map<string, { first: number; last: number; topLevel: boolean }>();
   for (const e of events) {
-    const tl = topLevelOf(e.sessionId);
-    const d = topDur.get(tl);
-    if (d) {
-      if (e.ts < d.first) d.first = e.ts;
-      if (e.ts > d.last) d.last = e.ts;
-    } else topDur.set(tl, { first: e.ts, last: e.ts });
+    if (!e.sessionId) continue;
+    const s = sess.get(e.sessionId);
+    if (s) {
+      if (e.ts < s.first) s.first = e.ts;
+      if (e.ts > s.last) s.last = e.ts;
+      if (!e.isSidechain) s.topLevel = true;
+    } else sess.set(e.sessionId, { first: e.ts, last: e.ts, topLevel: !e.isSidechain });
   }
-  const activeAt = makeConcurrency([...topDur.values()].map((d) => [d.first, d.last]));
+  const activeAt = makeConcurrency(
+    [...sess.values()].filter((s) => s.topLevel).map((s) => [s.first, s.last]),
+  );
+
+  // A top-level session is "subagent-heavy" if anything under it (orchestrator or a
+  // spawned subagent, rolled up by rootSessionId) ran as a subagent. The CLI counts
+  // the whole session-group's cost for this behaviour, not just the subagent requests.
+  const heavyRoot = new Set<string>();
+  for (const e of events) if (e.attributionAgent) heavyRoot.add(e.rootSessionId);
 
   let totalCost = 0;
   let longCtx = 0;
@@ -154,63 +134,60 @@ function buildWindow(
   const bySubagent = new Map<string, number>();
   const bySkill = new Map<string, number>();
   const byPlugin = new Map<string, number>();
-  const sessions = new Set<string>();
 
   for (const e of events) {
     const cost = estimateCost(e.model, e);
     if (cost <= 0) continue;
     totalCost += cost;
-    const tl = topLevelOf(e.sessionId);
-    sessions.add(tl);
 
-    // Behaviors (each an independent characteristic — shares can overlap). These
-    // are attributed at the *top-level session* grain: a session that spawned
-    // subagents counts its whole cost (orchestrator + children) as subagent-heavy,
-    // and a long-running orchestrator's whole cost counts as cron.
+    // Behaviours (independent characteristics — shares can overlap).
     const contextTokens = e.inputTokens + e.cacheReadTokens + e.cacheCreateTokens;
     if (contextTokens > CTX_THRESHOLD) longCtx += cost;
-    if (isHeavyTop(tl)) subagentHeavy += cost;
+    if (heavyRoot.has(e.rootSessionId)) subagentHeavy += cost;
     if (activeAt(e.ts) >= PARALLEL_MIN) highParallel += cost;
-    const dur = topDur.get(tl);
-    if (dur && dur.last - dur.first >= CRON_MS) cron += cost;
+    const s = sess.get(e.sessionId);
+    if (s && s.topLevel && s.last - s.first >= CRON_MS) cron += cost;
 
-    // Breakdowns.
-    const seenServers = new Set<string>();
-    for (const t of e.tools) {
-      const server = mcpServerOf(t);
-      if (server && !seenServers.has(server)) {
-        seenServers.add(server);
-        addTo(byMcp, server, cost);
-      }
-    }
-    if (e.isSidechain) addTo(bySubagent, subagentTypeOf(e.sessionId), cost);
-    for (const skill of e.skills) {
-      addTo(bySkill, skill, cost);
-      const sep = skill.indexOf(':');
-      if (sep > 0) addTo(byPlugin, skill.slice(0, sep), cost); // `plugin:skill`
-    }
+    // Breakdowns — straight from the CLI's attribution tags.
+    addTo(byMcp, e.attributionMcpServer, cost);
+    addTo(bySubagent, e.attributionAgent, cost);
+    addTo(bySkill, e.attributionSkill, cost);
+    addTo(byPlugin, e.attributionPlugin, cost);
   }
 
-  const behaviors: ContribBehavior[] = (
-    [
-      ['long_context', longCtx],
-      ['subagent_heavy', subagentHeavy],
-      ['high_parallel', highParallel],
-      ['cron', cron],
-    ] as Array<[ContribBehavior['key'], number]>
-  )
-    .map(([key, cost]) => ({
-      key,
-      pct: totalCost > 0 ? Math.round((cost / totalCost) * 100) : 0,
-    }))
+  const pct = (cost: number): number => (totalCost > 0 ? Math.round((cost / totalCost) * 100) : 0);
+
+  // Headline insights: the four behaviours plus any single MCP server / skill /
+  // plugin that alone exceeds the threshold (the CLI promotes these to headlines
+  // too, e.g. `22% of your usage came from MCP server "chrome-devtools"`).
+  const candidates: ContribBehavior[] = [
+    { key: 'subagent_heavy', pct: pct(subagentHeavy), headline: `${pct(subagentHeavy)}% of your usage came from subagent-heavy sessions`, body: 'Each subagent runs its own requests. Be deliberate about spawning them — and consider configuring a cheaper model for simpler subagents.' },
+    { key: 'long_context', pct: pct(longCtx), headline: `${pct(longCtx)}% of your usage was at >150k context`, body: 'Longer sessions are more expensive even when cached. /compact mid-task, /clear when switching to new tasks.' },
+    { key: 'high_parallel', pct: pct(highParallel), headline: `${pct(highParallel)}% of your usage was while 4+ sessions ran in parallel`, body: "All sessions share one limit. If you don't need them all at once, queueing uses it more evenly." },
+    { key: 'cron', pct: pct(cron), headline: `${pct(cron)}% of your usage came from sessions active for 8+ hours`, body: 'These are often background/loop sessions. Continuous usage can add up quickly so make sure it is intentional.' },
+  ];
+  const topMcp = toRows(byMcp, totalCost)[0];
+  if (topMcp && topMcp.pct >= SHOW_PCT) {
+    candidates.push({ key: `mcp:${topMcp.name}`, pct: topMcp.pct, headline: `${topMcp.pct}% of your usage came from MCP server "${topMcp.name}"`, body: MCP_BODY });
+  }
+  const topSkill = toRows(bySkill, totalCost)[0];
+  if (topSkill && topSkill.pct >= SHOW_PCT) {
+    candidates.push({ key: `skill:${topSkill.name}`, pct: topSkill.pct, headline: `${topSkill.pct}% of your usage came from /${topSkill.name}`, body: "This skill's instructions stay in context for the rest of the session." });
+  }
+  const topPlugin = toRows(byPlugin, totalCost)[0];
+  if (topPlugin && topPlugin.pct >= SHOW_PCT) {
+    candidates.push({ key: `plugin:${topPlugin.name}`, pct: topPlugin.pct, headline: `${topPlugin.pct}% of your usage came from plugin "${topPlugin.name}"`, body: 'Plugin skills and commands add to every request while active.' });
+  }
+
+  const behaviors = candidates
     .filter((b) => b.pct >= SHOW_PCT)
     .sort((a, b) => b.pct - a.pct)
-    .map((b) => ({ key: b.key, pct: b.pct, headline: headlineFor(b.key, b.pct), body: BEHAVIOR_BODY[b.key] }));
+    .slice(0, MAX_INSIGHTS);
 
   return {
     totalCost,
     requestCount: events.length,
-    sessionCount: sessions.size,
+    sessionCount: [...sess.values()].filter((s) => s.topLevel).length,
     behaviors,
     subagents: toRows(bySubagent, totalCost),
     mcpServers: toRows(byMcp, totalCost),
@@ -219,59 +196,10 @@ function buildWindow(
   };
 }
 
-export function buildContributors(
-  events: UsageEvent[],
-  insights: InsightsData,
-  now: number,
-): ContributorsData {
-  // agentId → subagent type (from Task spawns), then sessionId → type via session meta.
-  const typeByAgentId = new Map<string, string>();
-  for (const spawn of insights.taskSpawns) {
-    if (spawn.agentIdFromResult && spawn.subagentType) {
-      typeByAgentId.set(spawn.agentIdFromResult, spawn.subagentType);
-    }
-  }
-  const agentIdToSession = new Map<string, string>();
-  const typeBySession = new Map<string, string>();
-  for (const [sid, meta] of insights.sessionsMeta) {
-    if (meta.agentId) {
-      agentIdToSession.set(meta.agentId, sid);
-      if (typeByAgentId.has(meta.agentId)) typeBySession.set(sid, typeByAgentId.get(meta.agentId)!);
-    }
-  }
-  const subagentTypeOf = (sessionId: string): string => typeBySession.get(sessionId) ?? 'unknown';
-
-  // Session graph: a Task spawn ties a child (subagent) session to its parent, so a
-  // sidechain session resolves up to the top-level session that ultimately launched it.
-  const parentOf = new Map<string, string>();
-  for (const spawn of insights.taskSpawns) {
-    const childSid = spawn.agentIdFromResult ? agentIdToSession.get(spawn.agentIdFromResult) : undefined;
-    if (childSid && spawn.sessionId && childSid !== spawn.sessionId) parentOf.set(childSid, spawn.sessionId);
-  }
-  const topLevelOf = (sessionId: string): string => {
-    let cur = sessionId;
-    const guard = new Set<string>();
-    while (parentOf.has(cur) && !guard.has(cur)) {
-      guard.add(cur);
-      cur = parentOf.get(cur)!;
-    }
-    return cur;
-  };
-
-  // A top-level session is "subagent-heavy" if it spawned any subagent — either it
-  // is a parent in the graph, or its session meta records subagent spawns.
-  const heavyTop = new Set<string>();
-  for (const parentSid of parentOf.values()) heavyTop.add(topLevelOf(parentSid));
-  for (const [sid, meta] of insights.sessionsMeta) {
-    if (meta.subagentSpawns > 0) heavyTop.add(topLevelOf(sid));
-  }
-  const isHeavyTop = (topLevelId: string): boolean => heavyTop.has(topLevelId);
-
-  const buildFor = (windowMs: number): ContribWindow => {
+export function buildContributors(events: UsageEvent[], now: number): ContributorsData {
+  const windowOf = (windowMs: number): ContribWindow => {
     const from = now - windowMs;
-    const windowEvents = events.filter((e) => e.ts >= from && e.ts <= now);
-    return buildWindow(windowEvents, topLevelOf, isHeavyTop, subagentTypeOf);
+    return buildWindow(events.filter((e) => e.ts >= from && e.ts <= now));
   };
-
-  return { day: buildFor(DAY_MS), week: buildFor(WEEK_MS) };
+  return { day: windowOf(DAY_MS), week: windowOf(WEEK_MS) };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -360,13 +360,9 @@ app.get('/api/usage/models', async (req, res) => {
 app.get('/api/usage/contributors', async (req, res) => {
   try {
     const { events, computedAt } = await getEvents();
-    const { insights } = await getInsights();
     const source = parseSource(req.query.source);
-    const data = memoBuilder(
-      'contributors',
-      [source, insightsFingerprint()],
-      eventsFingerprint(),
-      () => buildContributors(filterSource(events, source), scopeInsights(insights, source), computedAt),
+    const data = memoBuilder('contributors', [source], eventsFingerprint(), () =>
+      buildContributors(filterSource(events, source), computedAt),
     );
     res.json(wrap(data, computedAt));
   } catch (e) {

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -17,8 +17,14 @@ export interface UsageEvent {
   cacheCreateTokens: number;
   cacheReadTokens: number;
   tools: string[]; // tool_use names invoked in this assistant message
-  skills: string[]; // Skill tool_use names invoked in this message (for cost attribution)
   isSidechain: boolean; // true when this message is a subagent (Task) sub-response
+  rootSessionId: string; // top-level session — for subagents, the parent that spawned them
+  // Per-request attribution written by the CLI itself (same tags Claude's usage
+  // view reads) — '' when absent. These make our breakdown match Claude exactly.
+  attributionAgent: string; // subagent type this request ran under
+  attributionSkill: string; // skill this request ran under
+  attributionMcpServer: string; // MCP server whose results sit in this request's context
+  attributionPlugin: string; // plugin this request ran under
   projectPath: string; // decoded path of the project directory
   gitBranch: string; // git branch at the time of the message ('' if unknown)
   source: UsageSource; // 'code' = Claude Code CLI, 'cowork' = desktop local-agent mode
@@ -160,6 +166,9 @@ async function parseFile(
   // A file under a `subagents/` segment is a subagent (Task) transcript — mirrors
   // insights-scan's isSubagentFile(). Used to attribute cost to subagent usage.
   const fileIsSidechain = /(^|[\\/])subagents([\\/])/.test(file);
+  // The parent that spawned these subagents is the path segment before `subagents/`
+  // (…/<parentSessionId>/subagents/…) — lets us roll subagent cost up to its session.
+  const parentFromPath = file.replace(/\\/g, '/').match(/\/([^/]+)\/subagents\//)?.[1] ?? '';
   const rl = createInterface({
     input: createReadStream(file, { encoding: 'utf8' }),
     crlfDelay: Infinity,
@@ -182,20 +191,14 @@ async function parseFile(
     if (Number.isNaN(ts)) continue;
 
     const tools: string[] = [];
-    const skills: string[] = [];
     const content = obj.message?.content;
     if (Array.isArray(content)) {
       for (const block of content) {
-        if (block?.type === 'tool_use' && typeof block.name === 'string') {
-          tools.push(block.name);
-          // A Skill invocation names the skill in its input — capture for attribution.
-          if (block.name === 'Skill') {
-            const s = block.input?.skill ?? block.input?.command ?? block.input?.name;
-            if (typeof s === 'string' && s) skills.push(s);
-          }
-        }
+        if (block?.type === 'tool_use' && typeof block.name === 'string') tools.push(block.name);
       }
     }
+
+    const attrStr = (v: unknown): string => (typeof v === 'string' ? v : '');
 
     const sessionId = obj.sessionId ?? obj.session_id ?? '';
     const resolvedProjectPath = (source === 'code' && sessionPathMap && sessionId)
@@ -212,8 +215,12 @@ async function parseFile(
       cacheCreateTokens: num(usage.cache_creation_input_tokens),
       cacheReadTokens: num(usage.cache_read_input_tokens),
       tools,
-      skills,
       isSidechain: fileIsSidechain || obj.isSidechain === true,
+      rootSessionId: (fileIsSidechain && parentFromPath) ? parentFromPath : sessionId,
+      attributionAgent: attrStr(obj.attributionAgent),
+      attributionSkill: attrStr(obj.attributionSkill),
+      attributionMcpServer: attrStr(obj.attributionMcpServer),
+      attributionPlugin: attrStr(obj.attributionPlugin),
       projectPath: resolvedProjectPath,
       gitBranch,
       source,

--- a/src/components/design-system/molecules/Toast/Toast.tsx
+++ b/src/components/design-system/molecules/Toast/Toast.tsx
@@ -19,11 +19,13 @@ export function Toast({ notification, onDismiss }: ToastProps) {
         <span className={`mt-0.5 shrink-0 ${s.iconColor}`}>{s.icon}</span>
         <div className="min-w-0 flex-1">
           <p className="font-semibold text-zinc-100">{notification.title}</p>
-          {notification.message && (
+          {notification.content ? (
+            <div className="mt-1 text-xs leading-relaxed text-zinc-400">{notification.content}</div>
+          ) : notification.message ? (
             <p className="mt-0.5 whitespace-pre-line text-xs leading-relaxed text-zinc-400">
               {notification.message}
             </p>
-          )}
+          ) : null}
           {notification.action && (
             <button
               onClick={notification.action.onClick}

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -14,6 +14,8 @@ export interface AppNotification {
   severity: Severity;
   title: string;
   message?: string;
+  /** Rich body (code blocks, links). Rendered instead of `message` when set. */
+  content?: ReactNode;
   dismissible: boolean;
   action?: NotificationAction;
   /** Fired when the user dismisses via the × (in addition to removal). Lets a
@@ -27,6 +29,7 @@ export interface NotifyOptions {
   severity?: Severity;
   title: string;
   message?: string;
+  content?: ReactNode;
   dismissible?: boolean;
   action?: NotificationAction;
   onDismiss?: () => void;
@@ -65,6 +68,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
         severity: opts.severity ?? 'info',
         title: opts.title,
         message: opts.message,
+        content: opts.content,
         dismissible: opts.dismissible ?? true,
         action: opts.action,
         onDismiss: opts.onDismiss,

--- a/src/hooks/useUpdateToast.tsx
+++ b/src/hooks/useUpdateToast.tsx
@@ -96,7 +96,7 @@ export function useUpdateToast(data: VersionInfo | null | undefined) {
         content: (
           <>
             <p>Running in Docker — pull latest and rebuild:</p>
-            <CodeBlock lines={['git pull', 'npm run docker:up']} />
+            <CodeBlock lines={['git checkout main', 'git pull', 'npm run docker:up']} />
             <ChangelogLink url={data.changelogUrl} />
           </>
         ),
@@ -119,7 +119,7 @@ export function useUpdateToast(data: VersionInfo | null | undefined) {
         content: (
           <>
             <p>Run it manually:</p>
-            <CodeBlock lines={['git pull', 'npm install']} />
+            <CodeBlock lines={['git checkout main', 'git pull', 'npm install']} />
             <ChangelogLink url={data.changelogUrl} />
           </>
         ),

--- a/src/hooks/useUpdateToast.tsx
+++ b/src/hooks/useUpdateToast.tsx
@@ -5,6 +5,30 @@ import type { VersionInfo } from '../types';
 const DISMISS_KEY = 'claude-dashboard-update-dismissed';
 type PullStatus = 'idle' | 'running' | 'done' | 'error';
 
+/** Monospace command block — renders shell commands so they read as code. */
+function CodeBlock({ lines }: { lines: string[] }) {
+  return (
+    <pre className="mt-1.5 overflow-x-auto rounded-md bg-black/40 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-zinc-200 ring-1 ring-white/10">
+      <code>{lines.join('\n')}</code>
+    </pre>
+  );
+}
+
+/** Real clickable changelog link. */
+function ChangelogLink({ url }: { url?: string }) {
+  if (!url) return null;
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mt-2 inline-block text-blue-400 underline underline-offset-2 hover:text-blue-300"
+    >
+      View changelog →
+    </a>
+  );
+}
+
 /**
  * Drives the "update available" toast (replaces the old inline UpdateBanner).
  * Keeps the dev-only self-update progress state and the per-version dismissal
@@ -49,7 +73,13 @@ export function useUpdateToast(data: VersionInfo | null | undefined) {
         id: 'update',
         severity: 'info',
         title: `Update available — v${data.current} → v${data.latest}`,
-        message: `Running in Docker — pull latest and rebuild:\ngit pull\nnpm run docker:up\n\nChangelog: ${data.changelogUrl}`,
+        content: (
+          <>
+            <p>Running in Docker — pull latest and rebuild:</p>
+            <CodeBlock lines={['git pull', 'npm run docker:up']} />
+            <ChangelogLink url={data.changelogUrl} />
+          </>
+        ),
         onDismiss,
       });
     } else if (pull === 'done') {
@@ -66,7 +96,13 @@ export function useUpdateToast(data: VersionInfo | null | undefined) {
         id: 'update',
         severity: 'warning',
         title: 'Auto-update failed',
-        message: `Run it manually:\ngit pull\nnpm install\n\nChangelog: ${data.changelogUrl}`,
+        content: (
+          <>
+            <p>Run it manually:</p>
+            <CodeBlock lines={['git pull', 'npm install']} />
+            <ChangelogLink url={data.changelogUrl} />
+          </>
+        ),
         onDismiss,
       });
     } else {
@@ -74,7 +110,7 @@ export function useUpdateToast(data: VersionInfo | null | undefined) {
         id: 'update',
         severity: 'info',
         title: `Update available — v${data.current} → v${data.latest}`,
-        message: `Changelog: ${data.changelogUrl}`,
+        content: <ChangelogLink url={data.changelogUrl} />,
         action: { label: pull === 'running' ? 'Updating…' : 'Update now', onClick: runUpdate },
         onDismiss,
       });

--- a/src/hooks/useUpdateToast.tsx
+++ b/src/hooks/useUpdateToast.tsx
@@ -5,12 +5,32 @@ import type { VersionInfo } from '../types';
 const DISMISS_KEY = 'claude-dashboard-update-dismissed';
 type PullStatus = 'idle' | 'running' | 'done' | 'error';
 
-/** Monospace command block — renders shell commands so they read as code. */
+/** Monospace command block — renders shell commands so they read as code,
+ *  with a copy-to-clipboard button. */
 function CodeBlock({ lines }: { lines: string[] }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard
+      ?.writeText(lines.join('\n'))
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  };
   return (
-    <pre className="mt-1.5 overflow-x-auto rounded-md bg-black/40 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-zinc-200 ring-1 ring-white/10">
-      <code>{lines.join('\n')}</code>
-    </pre>
+    <div className="relative mt-1.5">
+      <pre className="overflow-x-auto rounded-md bg-black/40 py-1.5 pl-2.5 pr-12 font-mono text-[11px] leading-relaxed text-zinc-200 ring-1 ring-white/10">
+        <code>{lines.join('\n')}</code>
+      </pre>
+      <button
+        onClick={copy}
+        title="Copy to clipboard"
+        className="absolute right-1 top-1 rounded px-1.5 py-0.5 text-[10px] font-semibold text-zinc-400 ring-1 ring-white/10 transition-colors hover:bg-white/10 hover:text-zinc-200"
+      >
+        {copied ? 'Copied ✓' : 'Copy'}
+      </button>
+    </div>
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ export interface LiveUsageData {
 
 // "What's contributing to your limits usage?" — cost-weighted Day/Week breakdown.
 export interface ContribBehavior {
-  key: 'long_context' | 'subagent_heavy' | 'high_parallel' | 'cron';
+  key: string; // 'long_context' | 'subagent_heavy' | … | 'mcp:<server>' | 'skill:<name>'
   headline: string;
   body: string;
   pct: number;


### PR DESCRIPTION
Follow-up to #24. Side-by-side with the Claude Code extension, the "What's contributing to your limits usage?" panel diverged: subagents showed as **unknown**, MCP servers were undercounted, skills were missing, and *subagent-heavy* read ~20% vs Claude's ~98%.

**Root cause:** the first cut *reconstructed* attribution with heuristics (path-based sidechain, MCP inferred from tool names in the calling message, subagent type via a session graph). Claude doesn't reconstruct — Claude Code writes per-request attribution onto every assistant message (`attributionAgent` / `attributionSkill` / `attributionMcpServer` / `attributionPlugin`) and the usage view reads those back.

**Fix — read the same tags:**
- `scan.ts`: capture the four attribution fields + `rootSessionId` (parent that spawned a subagent, from the `…/<parent>/subagents/` path); drop the `skills[]` heuristic.
- `contributors.ts`: build subagent/skill/MCP/plugin breakdowns straight from the tags — named subagents, correct MCP shares (incl. the whole-session-tail Claude attributes once a server is used). Count *subagent-heavy* at the session-group grain via `rootSessionId` (orchestrator + its subagents) so it matches Claude. Promote a dominant MCP/skill/plugin to a headline like the CLI does. Route no longer needs the insights scan.

**Parity now** (Day, this machine — vs Claude extension):

| | Claude | Now |
|---|---|---|
| subagent-heavy | 98% | 99% |
| >150k context | 67% | 65% |
| MCP chrome-devtools | 22% | 19% |
| MCP · Context7 / Gmail | 7% / 1% | 7% / 1% |
| Subagents | named | named (Explore/general-purpose/Plan) |

Residual: the "8+ hours" line is still a local session-span estimate; Claude's `cron` (background/loop) detection isn't recoverable from the logs, so that one figure can differ.

Verified: `tsc -b` clean; Docker rebuild; numbers + panel confirmed in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)