### PR TITLE
fix(docker): seed bundled CLI credentials from macOS Keychain cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.16] - 2026-07-09
+
+### Fixed
+- Ensure bundled CLI credentials are correctly seeded from macOS Keychain cache.
+- Improve error handling when the CLI's credentials file lacks an OAuth token. 
+
+### Changed
+- Internal maintenance and tooling.
+
 ## [0.1.15] - 2026-07-08
 
 ### Fixed
@@ -183,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.16]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.16
 [0.1.15]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.15
 [0.1.14]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.14
 [0.1.13]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN npm ci --omit=dev && npm install tsx@^4 && npm cache clean --force
 
 # App code + built frontend.
 COPY server ./server
+COPY scripts/seed-cli-credentials.mjs ./scripts/seed-cli-credentials.mjs
 COPY tsconfig.json ./
 COPY --from=build /app/dist ./dist
 
@@ -52,9 +53,6 @@ EXPOSE 8787
 # mount (the CLI refreshes tokens / writes logs, so it can't use the :ro mount),
 # then start the server. Without the CLI this is a no-op.
 CMD if command -v claude >/dev/null 2>&1 && [ -n "$CLAUDE_CONFIG_DIR" ]; then \
-      mkdir -p "$CLAUDE_CONFIG_DIR"; \
-      [ -f /data/.claude/.credentials.json ] && cp -f /data/.claude/.credentials.json "$CLAUDE_CONFIG_DIR/.credentials.json" || true; \
-      [ -f /data/.claude/settings.json ] && cp -f /data/.claude/settings.json "$CLAUDE_CONFIG_DIR/settings.json" || true; \
-      [ -f "$CLAUDE_CONFIG_DIR/.claude.json" ] || echo '{"hasCompletedOnboarding":true}' > "$CLAUDE_CONFIG_DIR/.claude.json"; \
+      node scripts/seed-cli-credentials.mjs; \
     fi; \
     exec npx tsx server/index.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/scripts/seed-cli-credentials.mjs
+++ b/scripts/seed-cli-credentials.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Runs at container startup (Dockerfile CMD) when WITH_CLAUDE_CLI=1, before the
+// server starts. `claude -p` needs a writable config dir — the ~/.claude mount
+// is read-only — so this seeds $CLAUDE_CONFIG_DIR from it. On macOS hosts the
+// real `claudeAiOauth` block lives in the Keychain, not in .credentials.json
+// (see readCredentials() in server/scan.ts), so `.credentials.json` alone often
+// has no claudeAiOauth — this merges in `.dashboard-oauth-cache.json` (written
+// by scripts/sync-macos-keychain.mjs) whenever that's the case, so the bundled
+// CLI ends up logged in the same way the dashboard's own OAuth calls already are.
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const claudeDir = process.env.CLAUDE_DIR || '/data/.claude';
+const configDir = process.env.CLAUDE_CONFIG_DIR;
+
+async function readJson(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  if (!configDir) return;
+  await mkdir(configDir, { recursive: true });
+
+  const destCredsPath = join(configDir, '.credentials.json');
+  let creds = (await readJson(join(claudeDir, '.credentials.json'))) || {};
+
+  if (!creds.claudeAiOauth?.accessToken) {
+    const cache = await readJson(join(claudeDir, '.dashboard-oauth-cache.json'));
+    if (cache?.claudeAiOauth?.accessToken) {
+      creds = { ...creds, claudeAiOauth: cache.claudeAiOauth };
+      if (cache.organizationUuid) creds.organizationUuid = cache.organizationUuid;
+    }
+  }
+  if (creds.claudeAiOauth || creds.mcpOAuth) {
+    await writeFile(destCredsPath, JSON.stringify(creds), 'utf8');
+  }
+
+  const settings = await readJson(join(claudeDir, 'settings.json'));
+  if (settings) await writeFile(join(configDir, 'settings.json'), JSON.stringify(settings), 'utf8');
+
+  const onboardingPath = join(configDir, '.claude.json');
+  if (!(await readJson(onboardingPath))) {
+    await writeFile(onboardingPath, JSON.stringify({ hasCompletedOnboarding: true }), 'utf8');
+  }
+}
+
+main().catch((e) => {
+  console.error('[seed-cli-credentials] skipped:', e.message);
+});


### PR DESCRIPTION
## Summary
- On macOS, Claude Code keeps the real `claudeAiOauth` token in the Keychain, not in `.credentials.json` — so the `WITH_CLAUDE_CLI=1` Docker image was seeding the bundled CLI's config dir with a credentials file missing the OAuth token, and `claude -p` reported "Not logged in" even though the dashboard's own OAuth calls (via `.dashboard-oauth-cache.json`) worked fine.
- Replaces the inline `cp`/`echo` seeding in the Dockerfile `CMD` with `scripts/seed-cli-credentials.mjs`, which falls back to merging in `claudeAiOauth` from `.dashboard-oauth-cache.json` when `.credentials.json` lacks it — mirroring the fallback already in `readCredentials()` (`server/scan.ts`).

## Test plan
- [x] `npx tsc -b` passes
- [x] `npm run docker:up` rebuilds cleanly with `WITH_CLAUDE_CLI=1`
- [x] Seeded `.credentials.json` inside the container now has a `claudeAiOauth.accessToken`
- [x] `claude --print` inside the container responds successfully instead of "Not logged in"
- [x] `/api/ai/status` reports `"available":"cli"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)