### PR TITLE
feat(ai): connect the Insights chat to all dashboard data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19] - 2026-07-14
+
+### Added
+- Display per-run cost and readable timestamps in the UI for better cost tracking.
+- Enable Insights chat to access every dashboard dataset for improved inquiries about workflow costs.
+- Include per-run estimated cost and all-time run rankings in the workflow data. 
+
+### Fixed
+- Correctly format run timestamps to show relative time more accurately.
+- Resolve chat UI issues preventing proper message handling and avoiding permanent "thinking…" states.
+
 ## [0.1.18] - 2026-07-13
 
 ### Fixed
@@ -220,6 +231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.19]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.19
 [0.1.18]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.18
 [0.1.17]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.17
 [0.1.16]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/ai-context.ts
+++ b/server/ai-context.ts
@@ -1,81 +1,257 @@
 /**
- * ai-context.ts — privacy-safe usage summary + prompt templates for AI Insights.
+ * ai-context.ts — the payload and prompts behind AI Insights.
  *
- * The context is AGGREGATES ONLY (no transcripts, no full project paths — project
- * basenames only). The user opts in by asking/clicking, so sending these
- * aggregates to the model is acceptable; raw logs never leave the machine.
+ * The model sees three things, always in one single-shot prompt:
+ *   1. an OVERVIEW of the account over ONE window (scope.days) on ONE surface
+ *      (scope.source) — every number in it is comparable to every other;
+ *   2. a CATALOG of every dataset the dashboard tracks, each flagged loaded or
+ *      not — so a retrieval miss becomes "I do track that, ask me about it"
+ *      instead of "the dashboard doesn't break things down that way";
+ *   3. the DETAIL blocks the router actually pulled (see ai-datasets.ts).
+ *
+ * Aggregates only: no transcripts, no full project paths (basenames only), no
+ * session identifiers. The user opts in by asking, so sending these aggregates
+ * to the model is acceptable; raw logs never leave the machine.
  */
 
-import { getEvents } from './cache.ts';
-import { getInsights } from './insights-scan.ts';
-import { buildWeekly, buildModels, buildTools, buildProjectStats } from './aggregate.ts';
-import { buildErrors, buildRetries, buildLanguages, buildMcp, buildYield, buildRejections, buildSubagentStats } from './insights.ts';
+import { getEvents, eventsFingerprint } from './cache.ts';
+import { getInsights, insightsFingerprint } from './insights-scan.ts';
+import { memoBuilder } from './builder-cache.ts';
+import { buildWeekly, buildModels, buildTools, buildProjectStats, filterSource, type SourceFilter } from './aggregate.ts';
+import { buildErrors, buildRetries, buildMcp, buildYield, buildRejections, buildSubagentStats, scopeInsights } from './insights.ts';
+import { fetchLiveUsage } from './scan.ts';
+import { CATALOG, loadDatasets, topN, datasetsDisabled, type DatasetId, type Slice } from './ai-datasets.ts';
 
-export interface AiContext {
+export interface AiScope {
+  source: SourceFilter;
+  days: number;
+}
+
+export interface AiPayload {
   generatedAt: string;
-  window: { weeklyDays: number; insightsDays: number };
-  totals: { weeklyEffectiveTokens: number; weeklyCost: number; prevWeeklyCost: number };
-  topModels: { model: string; effectiveTokens: number; cost: number }[];
-  topTools: { name: string; count: number }[];
-  topProjects: { name: string; cost: number; effectiveTokens: number; sessionCount: number }[];
+  scope: { source: SourceFilter; windowDays: number; from: string; to: string; note: string };
+  account: {
+    windowDays: number;
+    effectiveTokens: number;
+    totalTokens: number;
+    cacheReadTokens: number;
+    estCostUsd: number;
+    prevWindowEstCostUsd: number;
+    weeklyResetsAt: string;
+  };
+  limits: {
+    fiveHourPct: number | null;
+    sevenDayPct: number | null;
+    fiveHourResetsAt: string | null;
+    sevenDayResetsAt: string | null;
+    note: string;
+  } | { unavailable: string };
+  topModels: Slice<{ model: string; effectiveTokens: number; estCostUsd: number }>;
+  topTools: Slice<{ name: string; count: number }>;
+  topProjects: Slice<{ name: string; estCostUsd: number; effectiveTokens: number; sessions: number }>;
   behavior: {
-    errorRate: number;
-    oneShotRate: number;
+    errorRatePct: number;
+    oneShotRatePct: number;
     wastedTokens: number;
-    wastedCost: number;
-    delegationRate: number;
-    commitRate: number;
+    wastedEstCostUsd: number;
+    delegationRatePct: number;
+    commitRatePct: number;
     rejections: number;
-    topLanguages: { language: string; edits: number }[];
-    mcp: { builtinCalls: number; mcpCalls: number };
+    mcpCalls: number;
+    builtinCalls: number;
+  };
+  catalog: { id: DatasetId; describes: string; loaded: boolean }[];
+  detail: Record<string, unknown>;
+  notes: string[];
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const pct = (rate: number) => Math.round(rate * 1000) / 10;
+
+const MAX_DETAIL_BYTES = Number(process.env.AI_MAX_DETAIL_BYTES || 24 * 1024);
+const DETAIL_LIMIT_LADDER = [20, 10, 5];
+
+const NOTES: string[] = [
+  'Every number in `account`, `topModels`, `topTools`, `topProjects` and `behavior` covers EXACTLY scope.windowDays days on surface scope.source. Blocks inside `detail` state their own `window`/`source` whenever they differ. NEVER compare two numbers from different windows, and NEVER claim the data is inconsistent because of a window mismatch — check the windows first.',
+  'Any list with truncated:true shows only the top `shown` of `total` rows sorted by `sortedBy`, with the remainder rolled up in `other`. Never state a total, a count, or a "that is all of them" claim that depends on the hidden rows.',
+  'Workflow tokens and costs are a SUBSET of the account totals, never an addition — do not add them together.',
+  'Project stats exclude Cowork sessions (their paths are sandbox-internal), so per-project costs can sum to LESS than the account total. That is expected, not a bug.',
+  '`limits` is Anthropic\'s live account quota as a PERCENTAGE of a plan allowance. It covers every surface, ignores scope.source, and is a different unit from dollars — never mix the two.',
+  'All costs are ESTIMATED equivalent-API costs. This is a subscription with no per-token bill.',
+];
+
+// ── Payload cache ────────────────────────────────────────────────────────────
+// buildAiPayload runs a dozen O(events) builders. Every builder call below goes
+// through memoBuilder (sharing the dashboard's warm entries), and the assembled
+// payload is itself cached so /api/ai/chat and the /api/ai/suggestions call that
+// immediately follows it don't both pay for assembly.
+
+interface CacheEntry {
+  at: number;
+  payload: AiPayload;
+}
+const payloadCache = new Map<string, CacheEntry>();
+const PAYLOAD_TTL = 5_000;
+const PAYLOAD_MAX = 8;
+
+export async function buildAiPayload(
+  scope: AiScope,
+  ids: DatasetId[],
+  opts?: { redact?: boolean },
+): Promise<AiPayload> {
+  const redact = !!opts?.redact;
+  const key = [
+    scope.source,
+    scope.days,
+    redact,
+    [...ids].sort().join(','),
+    eventsFingerprint(),
+    insightsFingerprint(),
+  ].join('|');
+
+  const hit = payloadCache.get(key);
+  if (hit && Date.now() - hit.at < PAYLOAD_TTL) return hit.payload;
+
+  const payload = await assemble(scope, ids, redact);
+  if (payloadCache.size >= PAYLOAD_MAX) payloadCache.clear();
+  payloadCache.set(key, { at: Date.now(), payload });
+  return payload;
+}
+
+async function assemble(scope: AiScope, ids: DatasetId[], redact: boolean): Promise<AiPayload> {
+  const { source, days } = scope;
+  const [{ events, computedAt }, { insights }] = await Promise.all([getEvents(), getInsights()]);
+
+  // ONE window, ONE surface, driving every overview builder. The old context mixed
+  // a 7-day account total with 30-day project costs and labelled both "7 days",
+  // which is what made the model report a phantom inconsistency.
+  const scoped = filterSource(events, source);
+  const si = scopeInsights(insights, source);
+  const fp = eventsFingerprint();
+  const ifp = insightsFingerprint();
+
+  const weekly = memoBuilder('weekly', [days, source], fp, () => buildWeekly(scoped, computedAt, days));
+  const models = memoBuilder('models', [days, source], fp, () => buildModels(scoped, computedAt, days));
+  const tools = memoBuilder('tools', [days, source], fp, () => buildTools(scoped, computedAt, days));
+  const projects = memoBuilder('projects', [days, source], fp, () => buildProjectStats(scoped, computedAt, days));
+
+  const errors = memoBuilder('errors', [days, source], ifp, () => buildErrors(si, days));
+  const retries = memoBuilder('retries', [days, source], ifp, () => buildRetries(si, days));
+  const mcp = memoBuilder('mcp', [days, source], ifp, () => buildMcp(si, days));
+  const yld = memoBuilder('yield', [days, source], ifp, () => buildYield(si, days));
+  const rej = memoBuilder('rejections', [days, source], ifp, () => buildRejections(si, days));
+  const sub = memoBuilder('subagents', [days, source], ifp, () => buildSubagentStats(si, days));
+
+  const notes = [...NOTES];
+  const detail = await loadDetail(ids, { days, source, redact }, notes);
+  const loaded = new Set(Object.keys(detail));
+
+  return {
+    generatedAt: new Date(computedAt).toISOString(),
+    scope: {
+      source,
+      windowDays: days,
+      from: new Date(weekly.rangeFrom).toISOString(),
+      to: new Date(weekly.rangeTo).toISOString(),
+      note:
+        source === 'all'
+          ? 'Both surfaces: Claude Code and Cowork.'
+          : source === 'code'
+            ? 'Claude Code only (Cowork excluded).'
+            : 'Cowork only (Claude Code excluded).',
+    },
+    account: {
+      windowDays: days,
+      effectiveTokens: weekly.totals.effectiveTokens,
+      totalTokens: weekly.totals.totalTokens,
+      cacheReadTokens: weekly.totals.cacheReadTokens,
+      estCostUsd: round2(weekly.totals.cost),
+      prevWindowEstCostUsd: round2(weekly.prevTotals.cost),
+      weeklyResetsAt: new Date(weekly.weeklyResetsAt).toISOString(),
+    },
+    limits: await liveLimits(),
+    topModels: topN(
+      models.models.map((m) => ({ model: m.model, effectiveTokens: m.effectiveTokens, estCostUsd: round2(m.cost) })),
+      6,
+      'estCostUsd desc',
+      (rest) => ({ estCostUsd: round2(rest.reduce((s, m) => s + m.estCostUsd, 0)) }),
+    ),
+    topTools: topN(tools.tools, 10, 'count desc', (rest) => ({ count: rest.reduce((s, t) => s + t.count, 0) })),
+    topProjects: topN(
+      projects.projects.map((p) => ({
+        name: p.name,
+        estCostUsd: round2(p.cost),
+        effectiveTokens: p.effectiveTokens,
+        sessions: p.sessionCount,
+      })),
+      8,
+      'estCostUsd desc',
+      (rest) => ({ estCostUsd: round2(rest.reduce((s, p) => s + p.estCostUsd, 0)) }),
+    ),
+    behavior: {
+      errorRatePct: pct(errors.errorRate),
+      oneShotRatePct: pct(retries.oneShotRate),
+      wastedTokens: retries.wastedTokens,
+      wastedEstCostUsd: round2(retries.wastedCost),
+      delegationRatePct: pct(sub.delegationRate),
+      commitRatePct: pct(yld.rate),
+      rejections: rej.total,
+      mcpCalls: mcp.mcpCalls,
+      builtinCalls: mcp.builtinCalls,
+    },
+    catalog: CATALOG.map((c) => ({ ...c, loaded: loaded.has(c.id) })),
+    detail,
+    notes,
   };
 }
 
-export async function buildAiContext(now = Date.now()): Promise<AiContext> {
-  // Independent cache reads — run them together so a cold cache scans once in parallel.
-  const [{ events }, { insights }] = await Promise.all([getEvents(), getInsights()]);
+/** The account's live quota is the single most-asked thing and was never in the context. */
+async function liveLimits(): Promise<AiPayload['limits']> {
+  try {
+    const live: any = await fetchLiveUsage();
+    if (!live || live.error) return { unavailable: String(live?.error ?? 'live usage API unreachable') };
+    return {
+      fiveHourPct: live.five_hour?.utilization ?? null,
+      sevenDayPct: live.seven_day?.utilization ?? null,
+      fiveHourResetsAt: live.five_hour?.resets_at ?? null,
+      sevenDayResetsAt: live.seven_day?.resets_at ?? null,
+      note: 'Live Anthropic account quota, as a percentage of the plan allowance. Covers all surfaces; ignores scope.source. Not dollars.',
+    };
+  } catch (e) {
+    return { unavailable: e instanceof Error ? e.message : String(e) };
+  }
+}
 
-  const weekly = buildWeekly(events, now, 7);
-  const models = buildModels(events, now, 7);
-  const tools = buildTools(events, now, 7);
-  const projects = buildProjectStats(events, now, 30);
+/**
+ * Load the routed datasets under a byte budget. Shrinking the per-list limit is
+ * tried first; only when that isn't enough do we drop whole datasets — and a
+ * dropped dataset is *named* in the notes and flips to loaded:false in the
+ * catalog, so it degrades to honest rather than invisible.
+ */
+async function loadDetail(
+  ids: DatasetId[],
+  base: { days: number; source: SourceFilter; redact: boolean },
+  notes: string[],
+): Promise<Record<string, unknown>> {
+  if (ids.length === 0) return {};
+  if (datasetsDisabled()) {
+    notes.push('Detail datasets are disabled on this server (AI_DATASETS_DISABLED=1); only the overview is available.');
+    return {};
+  }
 
-  const errors = buildErrors(insights, 7);
-  const retries = buildRetries(insights, 7);
-  const langs = buildLanguages(insights, 7);
-  const mcp = buildMcp(insights, 7);
-  const yld = buildYield(insights, 7);
-  const rej = buildRejections(insights, 7);
-  const sub = buildSubagentStats(insights, 7);
+  let detail: Record<string, unknown> = {};
+  for (const limit of DETAIL_LIMIT_LADDER) {
+    detail = await loadDatasets(ids, { ...base, limit });
+    if (JSON.stringify(detail).length <= MAX_DETAIL_BYTES) return detail;
+  }
 
-  return {
-    generatedAt: new Date(now).toISOString(),
-    window: { weeklyDays: 7, insightsDays: 7 },
-    totals: {
-      weeklyEffectiveTokens: weekly.totals.effectiveTokens,
-      weeklyCost: weekly.totals.cost,
-      prevWeeklyCost: weekly.prevTotals.cost,
-    },
-    topModels: models.models.slice(0, 6).map((m) => ({ model: m.model, effectiveTokens: m.effectiveTokens, cost: m.cost })),
-    topTools: tools.tools.slice(0, 10),
-    topProjects: projects.projects.slice(0, 8).map((p) => ({
-      name: p.name,
-      cost: p.cost,
-      effectiveTokens: p.effectiveTokens,
-      sessionCount: p.sessionCount,
-    })),
-    behavior: {
-      errorRate: errors.errorRate,
-      oneShotRate: retries.oneShotRate,
-      wastedTokens: retries.wastedTokens,
-      wastedCost: retries.wastedCost,
-      delegationRate: sub.delegationRate,
-      commitRate: yld.rate,
-      rejections: rej.total,
-      topLanguages: langs.slice(0, 6).map((l) => ({ language: l.language, edits: l.edits })),
-      mcp: { builtinCalls: mcp.builtinCalls, mcpCalls: mcp.mcpCalls },
-    },
-  };
+  const [first, ...dropped] = ids;
+  if (dropped.length > 0) {
+    notes.push(
+      `Detail for ${dropped.join(', ')} was dropped to fit the context budget — say so and offer to answer about them one at a time.`,
+    );
+  }
+  return loadDatasets([first], { ...base, limit: DETAIL_LIMIT_LADDER[DETAIL_LIMIT_LADDER.length - 1] });
 }
 
 // ── Prompt templates ──────────────────────────────────────────────────────────
@@ -83,12 +259,24 @@ export async function buildAiContext(now = Date.now()): Promise<AiContext> {
 export const CHAT_SYSTEM = [
   'You are an analyst embedded in a personal Claude Code usage dashboard.',
   'You answer ONLY two kinds of questions:',
-  "(1) Questions about the user's Claude Code usage — answer using ONLY the JSON usage summary provided (aggregate metrics, no file contents or transcripts).",
+  "(1) Questions about the user's Claude Code usage — answer using ONLY the JSON payload provided (aggregate metrics; no file contents, no transcripts).",
   '(2) General questions about Claude, Claude Code, the Anthropic API, or Anthropic models — answer from your own knowledge.',
-  'For ANYTHING else (weather, news, trivia, unrelated coding help, math puzzles, etc.) do NOT answer: reply in one short sentence that you only cover the usage data shown here and general Claude / Claude Code questions.',
+  'For ANYTHING else (weather, news, trivia, unrelated coding help, math puzzles) do NOT answer: reply in one short sentence that you only cover the usage data shown here and general Claude / Claude Code questions.',
+  '',
+  'VOCABULARY IS EXACT. A "workflow" is one run of the workflow-orchestration tool (a generated script that fans out subagents across phases).',
+  'A "project" is a repo directory. A "session" is one CLI conversation. A "subagent" is a Task spawn.',
+  'If the user asks about one of these, NEVER answer about another. If you need a dataset you were not given, say so — do not substitute a different one.',
+  '',
+  '`catalog` lists EVERY dataset this dashboard tracks, each with loaded:true or loaded:false.',
+  'NEVER say the dashboard does not track something that appears in the catalog.',
+  'If you need an entry whose loaded is false, do not guess and do not deny it exists — say the dashboard does track it and ask the user to re-ask naming it (e.g. "ask me about file churn").',
+  '',
+  'Obey every string in `notes`.',
+  'Lists are already sorted — the answer to a "most/biggest/worst X" question is the first item of the relevant list; do not re-derive it.',
   'Costs are ESTIMATED equivalent API costs; the user is on a subscription with no per-token bill — say "estimated" when quoting money.',
-  '"Effective tokens" = input + output + cache-writes (counts toward limits); cache reads are excluded.',
-  'Be concise (~6 sentences max, or a short list). If the data cannot answer a usage question, say so plainly. Never invent numbers.',
+  '"Effective tokens" = input + output + cache-writes (what counts toward rate limits); cache reads are excluded.',
+  'Name the window with every number you quote. Never invent numbers.',
+  'Be concise (~6 sentences max, or a short list). If the payload cannot answer a usage question, say so plainly.',
 ].join(' ');
 
 export interface ChatTurn {
@@ -96,11 +284,11 @@ export interface ChatTurn {
   content: string;
 }
 
-export function buildChatUserMessage(ctx: AiContext, question: string, history?: ChatTurn[]): string {
+export function buildChatUserMessage(payload: AiPayload, question: string, history?: ChatTurn[]): string {
   const h = history && history.length
-    ? `\n\nEarlier in this conversation:\n${history.slice(-6).map((m) => `${m.role}: ${m.content}`).join('\n')}`
+    ? `\n\nEarlier in this conversation:\n${history.slice(-12).map((m) => `${m.role}: ${m.content}`).join('\n')}`
     : '';
-  return `USAGE SUMMARY (JSON):\n${JSON.stringify(ctx)}${h}\n\nQUESTION: ${question}`;
+  return `USAGE PAYLOAD (JSON):\n${JSON.stringify(scrubForModel(payload))}${h}\n\nQUESTION: ${question}`;
 }
 
 export const SECTION_SYSTEM =
@@ -127,19 +315,22 @@ const SECTION_PROMPTS: Record<string, string> = {
   complexity: 'Summarize this session-complexity data: which sessions are heaviest (tool calls, tokens, subagents) and what drives complexity.',
   tasks: 'Summarize this tasks & plans overview: completion rate, any blocked tasks, and the plan backlog.',
   plugins: 'Summarize this plugins & MCP inventory: installed plugins, MCP servers and any notable integrations.',
+  workflows: 'Summarize these workflow orchestration runs: which run cost the most, subagent counts, success rate, one takeaway.',
 };
 
 // Keys that may carry full paths or session identifiers. The privacy contract is
-// that those never leave the machine, so strip them from any panel payload before
-// it goes into a prompt bound for an external model (e.g. FileChurn's `path`,
-// Complexity's `sessionId`). Aggregate metrics and basenames are kept.
+// that those never leave the machine, so strip them from anything bound for an
+// external model. Defense-in-depth only — this is a key-name blocklist and cannot
+// see a path embedded inside a string VALUE. The allowlist projections in
+// ai-datasets.ts are the real boundary.
 const SENSITIVE_KEYS = new Set(
-  ['path', 'filePath', 'fullPath', 'projectPath', 'project_path', 'cwd', 'sessionId', 'transcriptPath'].map((k) =>
-    k.toLowerCase(),
-  ),
+  [
+    'path', 'filePath', 'fullPath', 'projectPath', 'project_path', 'cwd', 'sessionId', 'transcriptPath',
+    'runId', 'agentId', 'transcript', 'firstPrompt', 'logsTail',
+  ].map((k) => k.toLowerCase()),
 );
 
-function scrubForModel(value: unknown): unknown {
+export function scrubForModel(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(scrubForModel);
   if (value && typeof value === 'object') {
     const out: Record<string, unknown> = {};
@@ -161,13 +352,19 @@ export function buildSectionUserMessage(section: string, data: unknown): string 
 
 export const SUGGEST_SYSTEM = [
   'You suggest follow-up questions for a Claude Code usage dashboard chat.',
-  'Based on the conversation so far (and the usage summary), propose 3 short, specific follow-up questions the user is likely to ask next —',
+  'Based on the conversation so far (and the usage payload), propose 3 short, specific follow-up questions the user is likely to ask next —',
   'they should flow naturally from what was just discussed (drill deeper, compare, or a logical next step).',
-  'Every question must be answerable from the usage metrics OR from general Claude / Claude Code knowledge — never off-topic.',
+  'Every question must be answerable from the usage payload, from a dataset listed in its `catalog`, or from general Claude / Claude Code knowledge — never off-topic.',
+  'A question is only answerable if it names its dataset the way the catalog does (say "workflow", "session", "project" or "branch" explicitly).',
   'Return ONLY a JSON array of exactly 3 strings, each under 60 characters, e.g. ["...","...","..."]. No numbering, no prose, no markdown.',
 ].join(' ');
 
-export function buildSuggestMessage(ctx: AiContext, history: ChatTurn[]): string {
+export function buildSuggestMessage(payload: AiPayload, history: ChatTurn[]): string {
   const h = history.slice(-6).map((m) => `${m.role}: ${m.content}`).join('\n');
-  return `USAGE SUMMARY (JSON):\n${JSON.stringify(ctx)}\n\nCONVERSATION SO FAR:\n${h}\n\nReturn 3 follow-up questions as a JSON array of strings.`;
+  const slim = {
+    scope: payload.scope,
+    account: payload.account,
+    catalog: payload.catalog.map((c) => c.id),
+  };
+  return `USAGE PAYLOAD (JSON):\n${JSON.stringify(slim)}\n\nCONVERSATION SO FAR:\n${h}\n\nReturn 3 follow-up questions as a JSON array of strings.`;
 }

--- a/server/ai-datasets.ts
+++ b/server/ai-datasets.ts
@@ -1,0 +1,569 @@
+/**
+ * ai-datasets.ts — the retrieval layer behind AI Insights.
+ *
+ * Every surface the dashboard tracks is registered here as a *dataset*: a
+ * description the model always sees (the catalog), a lexical trigger that routes
+ * a question to it, and a loader that projects the backing builder into a
+ * model-safe shape.
+ *
+ * THIS FILE IS THE PRIVACY BOUNDARY. The hard rule, no exceptions:
+ *
+ *   NEVER spread a builder's return — project an explicit allowlist of fields.
+ *
+ * `scrubForModel` (ai-context.ts) is a key-name blocklist and cannot save us:
+ * `WorkflowRun.logsTail` is raw orchestration stdout, and `summary` /
+ * `phases[].detail` / `resultStats` are free text from a generated script — any
+ * of them can carry an absolute path *inside a string value*, which no key-name
+ * filter can strip. The projections below are the real boundary; the scrub is
+ * defense-in-depth.
+ */
+
+import { getEvents, eventsFingerprint } from './cache.ts';
+import { getInsights, insightsFingerprint } from './insights-scan.ts';
+import { memoBuilder } from './builder-cache.ts';
+import { buildHourlyHeatmap, filterSource, type SourceFilter } from './aggregate.ts';
+import {
+  buildErrors, buildRetries, buildLanguages, buildBranches, buildMcp,
+  buildComplexity, buildYield, buildRejections, buildSubagentStats, buildFileChurn, scopeInsights,
+} from './insights.ts';
+import { buildContributors } from './contributors.ts';
+import { getCommandUsage } from './history.ts';
+import { getWorkspaceTasks, getInventory } from './workspace.ts';
+import { getWorkflowStats, type WorkflowRunSummary } from './workflows.ts';
+import { fetchLiveUsage } from './scan.ts';
+
+export type DatasetId =
+  | 'workflows' | 'errors' | 'retries' | 'branches' | 'churn' | 'sessions' | 'commands'
+  | 'subagents' | 'mcp' | 'rejections' | 'languages' | 'yield' | 'contributors'
+  | 'heatmap' | 'limits' | 'tasks' | 'plugins';
+
+export interface DatasetQuery {
+  days: number;
+  source: SourceFilter;
+  limit: number;
+  /** True when the chat is pointed at a third-party provider (OpenAI/Gemini). */
+  redact: boolean;
+}
+
+/** Machine-readable provenance carried by EVERY list handed to the model. */
+export interface Slice<T> {
+  sortedBy: string;
+  shown: number;
+  total: number;
+  truncated: boolean;
+  items: T[];
+  other?: Record<string, number>;
+}
+
+/**
+ * Wrap THEN slice — never slice before wrapping, or `total` reports the clipped
+ * length and `truncated` reads false on a list that *was* truncated, which is the
+ * exact hallucination this provenance exists to prevent.
+ */
+export function topN<T>(
+  rows: T[],
+  n: number,
+  sortedBy: string,
+  rollup?: (rest: T[]) => Record<string, number>,
+): Slice<T> {
+  const items = rows.slice(0, n);
+  const rest = rows.slice(n);
+  const s: Slice<T> = { sortedBy, shown: items.length, total: rows.length, truncated: rest.length > 0, items };
+  // A partial list must still RECONCILE against the total, or the model "notices"
+  // that the top 8 sum to less than the account total and reports a phantom bug.
+  if (rest.length > 0 && rollup) s.other = { count: rest.length, ...rollup(rest) };
+  return s;
+}
+
+export interface DatasetDef {
+  id: DatasetId;
+  /** Goes VERBATIM into the catalog the model always sees. */
+  describes: string;
+  /** Lexical route — free, deterministic, works on every backend. */
+  trigger: RegExp;
+  load: (q: DatasetQuery) => Promise<unknown>;
+}
+
+const SOFT_TIMEOUT_MS = 1500;
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const pct = (rate: number) => Math.round(rate * 1000) / 10;
+
+/**
+ * A chat turn must never inherit a slow sidecar. `getWorkflows()` streams
+ * journal.jsonl and parses up to 24 agent transcripts while a run is live.
+ */
+function soft<T>(fn: () => Promise<T>, ms = SOFT_TIMEOUT_MS): Promise<T | null> {
+  return Promise.race([
+    fn().catch(() => null),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
+/** The window a block actually covers, stated in the block itself. */
+function win(days: number, now: number) {
+  return {
+    days,
+    from: new Date(now - days * 86_400_000).toISOString(),
+    to: new Date(now).toISOString(),
+  };
+}
+
+const REDACTED = {
+  redacted: 'Branch and file names are not sent to third-party model providers. Ask again with the local Claude backend to see them.',
+};
+
+// ── Scoped builder access ────────────────────────────────────────────────────
+// Memo keys deliberately reuse index.ts's BARE names so the AI path hits the
+// dashboard's already-warm entries instead of re-running O(events) aggregation
+// the dashboard just ran. Two rules keep the keys interchangeable — break either
+// and the dashboard's own route cache is silently poisoned:
+//   - event builders are called with now = computedAt from getEvents();
+//   - insights builders are called WITHOUT `now` (they default it).
+// The five `limit: Infinity` variants get their own ':full' keys because their
+// output differs from what the routes cache under the bare name.
+
+async function scopedInsights(source: SourceFilter) {
+  const { insights } = await getInsights();
+  return scopeInsights(insights, source);
+}
+
+// ── Row projections (the allowlist) ──────────────────────────────────────────
+
+function workflowSummaryRow(s: WorkflowRunSummary) {
+  return {
+    name: s.name,
+    project: s.project,
+    status: s.status,
+    effectiveTokens: s.tokens,
+    estCostUsd: round2(s.cost),
+    costBasis: s.costBasis,
+    subagents: s.agentCount,
+    toolCalls: s.toolCalls,
+    model: s.defaultModel,
+    durationMin: Math.round(s.durationMs / 60_000),
+    startedAt: new Date(s.startedAt).toISOString().slice(0, 10),
+  };
+}
+
+// ── The registry ─────────────────────────────────────────────────────────────
+
+export const DATASETS: DatasetDef[] = [
+  {
+    id: 'workflows',
+    describes:
+      'Workflow orchestration runs (the multi-agent Workflow tool: one generated script fanning out N subagents ' +
+      'across phases). Per-run name, project, status, subagent count, effective tokens, ESTIMATED cost and duration, ' +
+      'plus ALL-TIME top runs by cost. A workflow is NOT a project, a session, or a subagent.',
+    trigger: /\bwork[\s-]?flows?\b|\borchestrat|\bwf_|\bagent[\s-]?swarms?\b|\bfan[\s-]?out\b|\bmulti[\s-]?agent\b/i,
+    async load({ limit }) {
+      // Deliberately NOT getWorkflows(): it re-parses every final journal and takes
+      // ~8s on a real history, which a chat turn must never wait on. getWorkflowStats()
+      // peeks the same journals (memoized by path+mtime) in well under a second and
+      // covers ALL of them, not just the 90-day / 200-run window the list is capped to.
+      const stats = await soft(getWorkflowStats, 4000);
+      if (!stats) return { unavailable: 'workflow journals could not be read in time' };
+      return {
+        window: 'all-time',
+        source: 'code-only',
+        scopeNote:
+          'IGNORES the chat scope: these cover EVERY workflow journal on disk, Claude Code surface only (never Cowork). ' +
+          'Use `topRunsByCost` for "most expensive ever" and `recentRuns` for "what did I run lately".',
+        caveats: [
+          'estCostUsd is an ESTIMATED equivalent-API cost, not a bill.',
+          'costBasis "blended-run" prices a whole run at one blended rate from `model` (often literally "inherit", which falls back to a generic rate), so the ranking between close runs can be off. "per-agent" is priced per subagent model and is more reliable.',
+          'Currently-running workflows are not included — only finished runs that wrote a journal.',
+          'Workflow tokens are ALREADY inside the account totals — never add them on top.',
+        ],
+        allTime: {
+          totalRuns: stats.totalRuns,
+          completed: stats.completed,
+          failed: stats.failed,
+          successRatePct: pct(stats.successRate),
+          totalEffectiveTokens: stats.totalTokens,
+          estCostUsd: round2(stats.estCostUsd),
+          totalSubagents: stats.totalAgents,
+          topModel: stats.topModel,
+        },
+        topRunsByCost: topN(stats.topRunsByCost.map(workflowSummaryRow), limit, 'estCostUsd desc'),
+        recentRuns: topN(stats.recentRuns.map(workflowSummaryRow), limit, 'startedAt desc'),
+      };
+    },
+  },
+  {
+    id: 'errors',
+    describes:
+      'Tool-call failures: overall error rate, error categories, worst tools by call volume, and a DAY-BY-DAY error-rate trend.',
+    trigger: /\berrors?\b|\bfail(s|ed|ing|ure|ures)?\b|\berror[\s-]?rate\b|\bbroke\b|\bflaky\b/i,
+    async load({ days, source, limit }) {
+      const d = await scopedInsights(source);
+      const e = memoBuilder('errors:full', [days, source], insightsFingerprint(), () =>
+        buildErrors(d, days, undefined, Number.POSITIVE_INFINITY),
+      );
+      return {
+        window: win(days, Date.now()),
+        source,
+        totalCalls: e.totalCalls,
+        errors: e.errors,
+        errorRatePct: pct(e.errorRate),
+        categories: e.categories,
+        worstTools: topN(e.perTool, limit, 'calls desc'),
+        dailyTrend: e.trend, // [{date, calls, errors}] — the only place a trend exists
+      };
+    },
+  },
+  {
+    id: 'retries',
+    describes: 'Edit-retry analysis: one-shot success rate on Edit/Write, how many edits were retried, and the tokens/cost wasted on retries.',
+    trigger: /\bretr(y|ies|ied)\b|\bone[\s-]?shot\b|\bwasted?\b|\bre[\s-]?edit/i,
+    async load({ days, source }) {
+      const d = await scopedInsights(source);
+      const r = memoBuilder('retries', [days, source], insightsFingerprint(), () => buildRetries(d, days));
+      return {
+        window: win(days, Date.now()),
+        source,
+        totalEdits: r.totalEdits,
+        retried: r.retried,
+        oneShotRatePct: pct(r.oneShotRate),
+        wastedTokens: r.wastedTokens,
+        wastedEstCostUsd: round2(r.wastedCost),
+      };
+    },
+  },
+  {
+    id: 'branches',
+    describes: 'Per-git-branch usage: which branch (and repo) burned the most effective tokens and estimated cost, and over how many sessions.',
+    trigger: /\bbranch(es)?\b|\bgit\b|\brepo(sitor(y|ies))?\b|\bpr\b/i,
+    async load({ days, source, limit, redact }) {
+      if (redact) return REDACTED;
+      const d = await scopedInsights(source);
+      const rows = memoBuilder('branches:full', [days, source], insightsFingerprint(), () =>
+        buildBranches(d, days, undefined, Number.POSITIVE_INFINITY),
+      );
+      return {
+        window: win(days, Date.now()),
+        source,
+        branches: topN(
+          rows.map((b) => ({
+            branch: b.branch,
+            repo: b.repo,
+            effectiveTokens: b.effectiveTokens,
+            estCostUsd: round2(b.cost),
+            sessions: b.sessions,
+          })),
+          limit,
+          'effectiveTokens desc',
+          (rest) => ({
+            effectiveTokens: rest.reduce((s, b) => s + b.effectiveTokens, 0),
+            estCostUsd: round2(rest.reduce((s, b) => s + b.estCostUsd, 0)),
+          }),
+        ),
+      };
+    },
+  },
+  {
+    id: 'churn',
+    describes: 'File churn: which files were edited most often (the ones being rewritten over and over), and the total edit count.',
+    trigger: /\bchurn\b|\bfiles?\b|\bmost[\s-]?edited\b|\brewrit/i,
+    async load({ days, source, limit, redact }) {
+      if (redact) return REDACTED;
+      const d = await scopedInsights(source);
+      const c = memoBuilder('churn:full', [days, source], insightsFingerprint(), () =>
+        buildFileChurn(d, days, undefined, Number.POSITIVE_INFINITY),
+      );
+      return {
+        window: win(days, Date.now()),
+        source,
+        totalEdits: c.totalEdits,
+        uniqueFiles: c.uniqueFiles,
+        files: topN(
+          c.files.map((f) => ({ file: f.name, project: f.projectName, edits: f.edits })),
+          limit,
+          'edits desc',
+          (rest) => ({ edits: rest.reduce((s, f) => s + f.edits, 0) }),
+        ),
+      };
+    },
+  },
+  {
+    id: 'sessions',
+    describes:
+      'Per-session complexity: individual CLI conversations with their turn count, tool calls, subagents spawned, effective tokens and duration. ' +
+      'Use this for "which session was heaviest/longest/most expensive". A session is NOT a project and NOT a workflow.',
+    trigger: /\bsessions?\b|\bconversations?\b|\bchats?\b|\bcomplexit|\bheaviest\b|\blongest\b/i,
+    async load({ days, source, limit }) {
+      const d = await scopedInsights(source);
+      const rows = memoBuilder('complexity:full', [days, source], insightsFingerprint(), () =>
+        buildComplexity(d, days, undefined, Number.POSITIVE_INFINITY),
+      );
+      return {
+        window: win(days, Date.now()),
+        source,
+        totalSessions: rows.length,
+        // sessionId is deliberately dropped — it is an identifier, not a metric.
+        heaviestSessions: topN(
+          rows.map((s) => ({
+            project: s.project,
+            date: s.date,
+            turns: s.turns,
+            toolCalls: s.toolCalls,
+            subagents: s.subagents,
+            effectiveTokens: s.effectiveTokens,
+            durationMin: s.durationMin,
+          })),
+          limit,
+          'effectiveTokens desc',
+          (rest) => ({ effectiveTokens: rest.reduce((s, r) => s + r.effectiveTokens, 0) }),
+        ),
+      };
+    },
+  },
+  {
+    id: 'commands',
+    describes: 'Slash-command and skill usage: which /commands and skills were invoked and how often.',
+    trigger: /\bslash\b|\bcommands?\b|\bskills?\b|\/\w+/i,
+    async load({ days, limit }) {
+      const c = await soft(() => getCommandUsage(days));
+      if (!c) return { unavailable: 'command history could not be read in time' };
+      return {
+        window: win(days, Date.now()),
+        source: 'account',
+        scopeNote: 'Read from the CLI history file — it is not split by surface.',
+        totalCommands: c.totalCommands,
+        uniqueCommands: c.uniqueCommands,
+        commands: topN(c.commands, limit, 'count desc', (rest) => ({ count: rest.reduce((s, x) => s + x.count, 0) })),
+      };
+    },
+  },
+  {
+    id: 'subagents',
+    describes: 'Subagent delegation: how many Task subagents were spawned, by agent type and by model, and the share of sessions that delegate.',
+    trigger: /\bsub[\s-]?agents?\b|\bdelegat|\btask tool\b|\bspawn/i,
+    async load({ days, source }) {
+      const d = await scopedInsights(source);
+      const s = memoBuilder('subagents', [days, source], insightsFingerprint(), () => buildSubagentStats(d, days));
+      return {
+        window: win(days, Date.now()),
+        source,
+        spawns: s.spawns,
+        byType: s.byType,
+        byModel: s.byModel,
+        avgPerSession: s.avgPerSession,
+        delegationRatePct: pct(s.delegationRate),
+      };
+    },
+  },
+  {
+    id: 'mcp',
+    describes: 'MCP vs built-in tool split: how many calls went to MCP servers vs built-in tools, and per-MCP-server call and error counts.',
+    trigger: /\bmcp\b|\bservers?\b|\bbuilt[\s-]?in\b|\bintegrations?\b/i,
+    async load({ days, source, limit }) {
+      const d = await scopedInsights(source);
+      const m = memoBuilder('mcp', [days, source], insightsFingerprint(), () => buildMcp(d, days));
+      return {
+        window: win(days, Date.now()),
+        source,
+        builtinCalls: m.builtinCalls,
+        mcpCalls: m.mcpCalls,
+        perServer: topN(m.perServer, limit, 'calls desc'),
+      };
+    },
+  },
+  {
+    id: 'rejections',
+    describes: 'Permission rejections: how many tool calls the user denied, broken down per tool.',
+    trigger: /\breject|\bdenied?\b|\bpermissions?\b|\bblocked\b/i,
+    async load({ days, source, limit }) {
+      const d = await scopedInsights(source);
+      const r = memoBuilder('rejections', [days, source], insightsFingerprint(), () => buildRejections(d, days));
+      return {
+        window: win(days, Date.now()),
+        source,
+        total: r.total,
+        perTool: topN(r.perTool, limit, 'rejections desc'),
+      };
+    },
+  },
+  {
+    id: 'languages',
+    describes: 'Language / file-type breakdown: which languages were edited and read most.',
+    trigger: /\blanguages?\b|\bfile[\s-]?types?\b|\btypescript\b|\bpython\b|\bwhat.*(do i|am i) (writ|cod)/i,
+    async load({ days, source, limit }) {
+      const d = await scopedInsights(source);
+      const langs = memoBuilder('languages', [days, source], insightsFingerprint(), () => buildLanguages(d, days));
+      return {
+        window: win(days, Date.now()),
+        source,
+        languages: topN(langs, limit, 'edits desc', (rest) => ({ edits: rest.reduce((s, l) => s + l.edits, 0) })),
+      };
+    },
+  },
+  {
+    id: 'yield',
+    describes: 'Committed-vs-uncommitted yield: what share of sessions ended in a git commit, and the tokens spent on sessions that never landed.',
+    trigger: /\byield\b|\bcommit(s|ted|ting)?\b|\buncommitted\b|\bland(ed)?\b|\bshipped?\b/i,
+    async load({ days, source, limit }) {
+      const d = await scopedInsights(source);
+      const y = memoBuilder('yield:full', [days, source], insightsFingerprint(), () =>
+        buildYield(d, days, undefined, Number.POSITIVE_INFINITY),
+      );
+      return {
+        window: win(days, Date.now()),
+        source,
+        committedSessions: y.committed,
+        uncommittedSessions: y.uncommitted,
+        commitRatePct: pct(y.rate),
+        tokensCommitted: y.tokensCommitted,
+        tokensUncommitted: y.tokensUncommitted,
+        topUncommitted: topN(y.topUncommitted, limit, 'effectiveTokens desc'),
+      };
+    },
+  },
+  {
+    id: 'contributors',
+    describes:
+      'What is driving your rate-limit usage: a cost-weighted Day and Week breakdown by behavior, subagent, MCP server, skill and plugin ' +
+      '(the same panel the Claude CLI shows).',
+    trigger: /\bcontribut|\bwhat.?s driving\b|\bdrives?\b|\bwhat.*(using|eating|burning).*(limit|quota)\b/i,
+    async load({ source, limit }) {
+      const { events, computedAt } = await getEvents();
+      const c = memoBuilder('contributors', [source], eventsFingerprint(), () =>
+        buildContributors(filterSource(events, source), computedAt),
+      );
+      const projectWindow = (w: typeof c.day) => ({
+        totalEstCostUsd: round2(w.totalCost),
+        requestCount: w.requestCount,
+        sessionCount: w.sessionCount,
+        behaviors: w.behaviors.map((b) => ({ key: b.key, headline: b.headline, pct: b.pct })),
+        subagents: topN(w.subagents, limit, 'pct desc'),
+        mcpServers: topN(w.mcpServers, limit, 'pct desc'),
+        skills: topN(w.skills, limit, 'pct desc'),
+        plugins: topN(w.plugins, limit, 'pct desc'),
+      });
+      return {
+        window: 'native',
+        source,
+        scopeNote: 'IGNORES the chat window: `day` is the last 24h and `week` is the last 7 days, always.',
+        day: projectWindow(c.day),
+        week: projectWindow(c.week),
+      };
+    },
+  },
+  {
+    id: 'heatmap',
+    describes: 'When you work: a 7×24 grid of effective tokens by day-of-week (Mon=0) and hour-of-day (local time).',
+    trigger: /\bheat[\s-]?map\b|\bwhat time\b|\bhour(s|ly)?\b|\btime of day\b|\bwhen do i\b|\bpeak\b/i,
+    async load({ days, source }) {
+      const { events, computedAt } = await getEvents();
+      const h = memoBuilder('heatmap', [days, source], eventsFingerprint(), () =>
+        buildHourlyHeatmap(filterSource(events, source), computedAt, days),
+      );
+      return {
+        window: win(days, computedAt),
+        source,
+        legend: 'grid[dayOfWeek][hour] = effective tokens. dayOfWeek 0=Mon..6=Sun, hour 0..23, local time.',
+        grid: h.grid,
+      };
+    },
+  },
+  {
+    id: 'limits',
+    describes:
+      "Anthropic's LIVE rate-limit quota for the account: the 5-hour and 7-day utilization percentages, when they reset, " +
+      'and any extra-usage/overage credits. This is a percentage of a plan allowance — NOT dollars, and NOT the estimated costs elsewhere.',
+    trigger: /\blimits?\b|\bquota\b|\brate[\s-]?limit\b|\breset/i,
+    async load() {
+      const live: any = await soft(fetchLiveUsage);
+      if (!live || live.error) return { unavailable: String(live?.error ?? 'live usage API unreachable') };
+      return {
+        window: 'native',
+        source: 'account',
+        scopeNote: 'Live from Anthropic, covers the whole account across all surfaces. IGNORES the chat scope.',
+        fiveHourPct: live.five_hour?.utilization ?? null,
+        fiveHourResetsAt: live.five_hour?.resets_at ?? null,
+        sevenDayPct: live.seven_day?.utilization ?? null,
+        sevenDayResetsAt: live.seven_day?.resets_at ?? null,
+        sevenDayOpusPct: live.seven_day_opus?.utilization ?? null,
+        extraUsageEnabled: live.extra_usage?.is_enabled ?? null,
+        extraUsagePct: live.extra_usage?.utilization ?? null,
+      };
+    },
+  },
+  {
+    id: 'tasks',
+    describes: 'Tasks & plans backlog: task count by status, completion rate, blocked tasks, and saved plan files.',
+    trigger: /\btasks?\b|\bplans?\b|\bbacklog\b|\bblocked\b|\btodos?\b/i,
+    async load({ limit }) {
+      const t = await soft(getWorkspaceTasks);
+      if (!t) return { unavailable: 'workspace tasks could not be read in time' };
+      return {
+        window: 'all-time',
+        source: 'account',
+        totalTasks: t.tasks.total,
+        byStatus: t.tasks.byStatus,
+        completionRatePct: pct(t.tasks.completionRate),
+        blocked: t.tasks.items.filter((i) => i.blocked).map((i) => ({ subject: i.subject, status: i.status })),
+        tasks: topN(t.tasks.items.map((i) => ({ subject: i.subject, status: i.status, blocked: i.blocked })), limit, 'insertion order'),
+        totalPlans: t.plans.total,
+        plans: topN(t.plans.items.map((p) => ({ title: p.title, ageDays: p.ageDays })), limit, 'insertion order'),
+      };
+    },
+  },
+  {
+    id: 'plugins',
+    describes: 'Installed inventory: plugins, their marketplaces, configured MCP servers, and active hooks.',
+    trigger: /\bplugins?\b|\bmarketplaces?\b|\binventory\b|\bhooks?\b|\binstalled\b/i,
+    async load() {
+      const inv = await soft(getInventory);
+      if (!inv) return { unavailable: 'inventory could not be read in time' };
+      return {
+        window: 'all-time',
+        source: 'account',
+        plugins: inv.plugins.map((p) => ({ name: p.name, marketplace: p.marketplace, version: p.version })),
+        enabledPlugins: inv.enabledPlugins,
+        marketplaces: inv.marketplaces,
+        mcpServers: inv.mcpServers,
+        hooks: inv.hooks,
+        model: inv.model,
+        effortLevel: inv.effortLevel,
+      };
+    },
+  },
+];
+
+const BY_ID = new Map(DATASETS.map((d) => [d.id, d]));
+
+export const CATALOG: { id: DatasetId; describes: string }[] = DATASETS.map((d) => ({
+  id: d.id,
+  describes: d.describes,
+}));
+
+export function datasetsDisabled(): boolean {
+  return process.env.AI_DATASETS_DISABLED === '1';
+}
+
+/** Deterministic keyword routing — zero model calls, works on every backend. */
+export function lexicalRoute(text: string, max = 3): DatasetId[] {
+  const hits: DatasetId[] = [];
+  for (const d of DATASETS) {
+    if (d.trigger.test(text)) hits.push(d.id);
+    if (hits.length >= max) break;
+  }
+  return hits;
+}
+
+/** Load the routed datasets. A loader that fails degrades to `{unavailable}` — never throws. */
+export async function loadDatasets(ids: DatasetId[], q: DatasetQuery): Promise<Record<string, unknown>> {
+  if (datasetsDisabled()) return {};
+  const out: Record<string, unknown> = {};
+  const wanted = ids.filter((id) => BY_ID.has(id));
+  await Promise.all(
+    wanted.map(async (id) => {
+      try {
+        out[id] = await BY_ID.get(id)!.load(q);
+      } catch (e) {
+        out[id] = { unavailable: e instanceof Error ? e.message : String(e) };
+      }
+    }),
+  );
+  return out;
+}

--- a/server/ai-router.ts
+++ b/server/ai-router.ts
@@ -1,0 +1,96 @@
+/**
+ * ai-router.ts — decides which datasets a question needs.
+ *
+ * The chat can NEVER fail because of retrieval. The ladder degrades, in order:
+ *   1. AI_ROUTER=off                      → overview only
+ *   2. lexical hit                        → zero extra model calls (every backend)
+ *   3. no hit, CLI backend, no user key   → skip the router; a `claude --print`
+ *                                           spawn costs 2-4s and the catalog makes
+ *                                           an unrouted answer honest anyway
+ *   4. no hit, API backend                → one cheap model call to pick datasets
+ *   5. anything throws                    → overview only
+ *
+ * server/ai.ts is deliberately not modified: the `claude --print` backend has no
+ * tool channel at all, so a tool_use loop would be dead on the app's most common
+ * backend. This routes with plain text calls instead, which every backend has.
+ */
+
+import { runAi, resolveBackend, type AiCreds } from './ai.ts';
+import { CATALOG, lexicalRoute, datasetsDisabled, type DatasetId } from './ai-datasets.ts';
+import type { ChatTurn } from './ai-context.ts';
+
+export interface RouteResult {
+  ids: DatasetId[];
+  via: 'lexical' | 'model' | 'none';
+}
+
+const MAX_DATASETS = 3;
+const VALID = new Set<string>(CATALOG.map((c) => c.id));
+
+const ROUTER_SYSTEM = [
+  'You route a question about a Claude Code usage dashboard to the datasets that can answer it.',
+  `Return ONLY a JSON array of at most ${MAX_DATASETS} dataset ids from the catalog, most relevant first, e.g. ["workflows"].`,
+  'Return [] if the question needs no dataset (it is small talk, or general Claude knowledge, or the overview alone answers it).',
+  'No prose, no markdown, no explanation — just the JSON array.',
+].join(' ');
+
+function mode(): 'auto' | 'model' | 'lexical' | 'off' {
+  const m = process.env.AI_ROUTER;
+  return m === 'model' || m === 'lexical' || m === 'off' ? m : 'auto';
+}
+
+/** Tolerant parse — same spirit as parseSuggestions: models like to add prose. */
+function parseIds(text: string): DatasetId[] {
+  const start = text.indexOf('[');
+  const end = text.lastIndexOf(']');
+  if (start === -1 || end <= start) return [];
+  try {
+    const arr = JSON.parse(text.slice(start, end + 1));
+    if (!Array.isArray(arr)) return [];
+    return arr.filter((x): x is DatasetId => typeof x === 'string' && VALID.has(x)).slice(0, MAX_DATASETS);
+  } catch {
+    return [];
+  }
+}
+
+export async function routeDatasets(
+  question: string,
+  history: ChatTurn[],
+  creds: AiCreds | null,
+): Promise<RouteResult> {
+  const m = mode();
+  if (m === 'off' || datasetsDisabled()) return { ids: [], via: 'none' };
+
+  // The last couple of turns matter: "and how many tokens?" carries no keywords
+  // of its own, but the workflow question two lines up does.
+  const text = [question, ...history.slice(-2).map((t) => t.content)].join('\n');
+
+  if (m !== 'model') {
+    const hits = lexicalRoute(text, MAX_DATASETS);
+    if (hits.length > 0) return { ids: hits, via: 'lexical' };
+    if (m === 'lexical') return { ids: [], via: 'none' };
+  }
+
+  try {
+    // Spawning `claude --print` just to route costs 2-4s on top of the answer.
+    // The catalog makes an unrouted answer honest, so on the CLI we skip it.
+    if (!creds && m === 'auto') {
+      const status = await resolveBackend();
+      if (status.available === 'cli') return { ids: [], via: 'none' };
+      if (status.available === 'none') return { ids: [], via: 'none' };
+    }
+    const catalog = CATALOG.map((c) => `${c.id}: ${c.describes}`).join('\n');
+    const { text: out } = await runAi(
+      {
+        system: ROUTER_SYSTEM,
+        user: `CATALOG:\n${catalog}\n\nQUESTION: ${question}\n\nReturn the JSON array of dataset ids.`,
+        maxTokens: 80,
+      },
+      creds,
+    );
+    const ids = parseIds(out);
+    return ids.length > 0 ? { ids, via: 'model' } : { ids: [], via: 'none' };
+  } catch {
+    return { ids: [], via: 'none' };
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,8 @@ import { getWorkspaceTasks, getInventory } from './workspace.ts';
 import { getLiveSubagents } from './subagents-live.ts';
 import { getWorkflows, getWorkflowStats } from './workflows.ts';
 import { runAi, runAiStream, resolveBackend, AiUnavailableError, AiTokenRejectedError, AiCallError, type AiCreds } from './ai.ts';
-import { buildAiContext, buildChatUserMessage, CHAT_SYSTEM, buildSectionUserMessage, SECTION_SYSTEM, SUGGEST_SYSTEM, buildSuggestMessage, type ChatTurn } from './ai-context.ts';
+import { buildAiPayload, buildChatUserMessage, CHAT_SYSTEM, buildSectionUserMessage, SECTION_SYSTEM, SUGGEST_SYSTEM, buildSuggestMessage, type AiScope, type ChatTurn } from './ai-context.ts';
+import { routeDatasets } from './ai-router.ts';
 import { getVersionInfo, isDocker } from './version.ts';
 import {
   getState as getAutoResumeState,
@@ -753,6 +754,24 @@ function parseSuggestions(text: string): string[] {
   return out.map((s) => s.trim()).filter(Boolean).slice(0, 4);
 }
 
+/**
+ * The chat answers over ONE window on ONE surface, both taken from what the user
+ * is actually looking at. Every overview number then shares a window, so the model
+ * can never "notice" a phantom inconsistency between two differently-scoped figures.
+ */
+function parseAiScope(body: any): AiScope {
+  return { source: parseSource(body?.source), days: clampDays(body?.days, 30) };
+}
+
+/**
+ * Full detail (branch names, file paths) only goes to a backend the user already
+ * trusts with their code — the local `claude` CLI, their Claude.ai OAuth token, or
+ * their own Anthropic key. An OpenAI/Gemini key from Settings gets those redacted.
+ */
+function shouldRedact(creds: AiCreds | null): boolean {
+  return !!creds && creds.provider !== 'claude';
+}
+
 /** Validate client-supplied AI credentials (Settings → AI Insights). */
 function parseAiCreds(raw: any): AiCreds | null {
   if (!raw || typeof raw !== 'object') return null;
@@ -781,15 +800,21 @@ app.post('/api/ai/chat', async (req, res) => {
       return;
     }
     const history = parseHistory(req.body?.history);
-    const ctx = await buildAiContext();
     const creds = parseAiCreds(req.body?.config);
+    const scope = parseAiScope(req.body);
+    const route = await routeDatasets(question, history, creds);
+    const payload = await buildAiPayload(scope, route.ids, { redact: shouldRedact(creds) });
     // Stream the answer as chunked text/plain. Headers flush on the first delta;
     // an error before any delta is still sent as JSON (headers not yet sent).
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
     res.setHeader('Cache-Control', 'no-cache, no-transform');
     res.setHeader('X-Accel-Buffering', 'no');
+    // With no tests and no HMR, these two headers are the whole debugging surface
+    // for "why did it answer from that?". They must be set before the first write.
+    res.setHeader('X-AI-Route', route.via);
+    res.setHeader('X-AI-Datasets', route.ids.join(','));
     await runAiStream(
-      { system: CHAT_SYSTEM, user: buildChatUserMessage(ctx, question, history) },
+      { system: CHAT_SYSTEM, user: buildChatUserMessage(payload, question, history), maxTokens: 1200 },
       creds,
       {
         onStart: (backend) => res.setHeader('X-AI-Backend', backend),
@@ -838,13 +863,28 @@ app.post('/api/ai/suggestions', async (req, res) => {
       res.json(wrap({ suggestions: [] }, Date.now()));
       return;
     }
-    const ctx = await buildAiContext();
     const creds = parseAiCreds(req.body?.config);
+    // Overview only: the chips just need the catalog to know what is askable.
+    const payload = await buildAiPayload(parseAiScope(req.body), [], { redact: shouldRedact(creds) });
     const { text } = await runAi(
-      { system: SUGGEST_SYSTEM, user: buildSuggestMessage(ctx, history), maxTokens: 200 },
+      { system: SUGGEST_SYSTEM, user: buildSuggestMessage(payload, history), maxTokens: 200 },
       creds,
     );
     res.json(wrap({ suggestions: parseSuggestions(text) }, Date.now()));
+  } catch (e) {
+    sendAiError(res, e);
+  }
+});
+
+/**
+ * The privacy disclosure: exactly what the chat would send to the model, before
+ * sending it. The AI tab also pings this on mount to warm the aggregate caches so
+ * the first question doesn't pay for a cold insights scan.
+ */
+app.get('/api/ai/context', async (req, res) => {
+  try {
+    const payload = await buildAiPayload(parseAiScope(req.query), []);
+    res.json(wrap(payload, Date.now()));
   } catch (e) {
     sendAiError(res, e);
   }

--- a/server/insights.ts
+++ b/server/insights.ts
@@ -62,7 +62,7 @@ function classifyError(text: string, rejected: boolean): string {
 // buildErrors
 // ---------------------------------------------------------------------------
 
-export function buildErrors(d: InsightsData, days: number, now = Date.now()) {
+export function buildErrors(d: InsightsData, days: number, now = Date.now(), perToolLimit = 12) {
   const from = cutoff(days, now);
   const filtered = d.toolCalls.filter((tc) => tc.ts >= from);
 
@@ -109,7 +109,7 @@ export function buildErrors(d: InsightsData, days: number, now = Date.now()) {
       errorRate: v.calls > 0 ? v.errors / v.calls : 0,
     }))
     .sort((a, b) => b.calls - a.calls)
-    .slice(0, 12);
+    .slice(0, perToolLimit);
 
   const trend = [...trendMap.entries()]
     .map(([date, v]) => ({ date, calls: v.calls, errors: v.errors }))
@@ -121,6 +121,7 @@ export function buildErrors(d: InsightsData, days: number, now = Date.now()) {
     errorRate: totalCalls > 0 ? errors / totalCalls : 0,
     categories,
     perTool,
+    perToolTotal: perToolMap.size, // real row count — `perTool` above is clipped
     trend,
   };
 }
@@ -262,7 +263,7 @@ export function buildLanguages(d: InsightsData, days: number, now = Date.now()) 
 // buildBranches
 // ---------------------------------------------------------------------------
 
-export function buildBranches(d: InsightsData, days: number, now = Date.now()) {
+export function buildBranches(d: InsightsData, days: number, now = Date.now(), limit = 10) {
   const from = cutoff(days, now);
   // Key by repo + branch so the same branch name (e.g. "main") in different repos
   // stays separate and each row can be attributed to its repository.
@@ -296,7 +297,7 @@ export function buildBranches(d: InsightsData, days: number, now = Date.now()) {
       sessions: v.sessions.size,
     }))
     .sort((a, b) => b.effectiveTokens - a.effectiveTokens)
-    .slice(0, 10);
+    .slice(0, limit);
 }
 
 // ---------------------------------------------------------------------------
@@ -350,7 +351,7 @@ export interface ComplexityPoint {
   date: string;
 }
 
-export function buildComplexity(d: InsightsData, days: number, now = Date.now()): ComplexityPoint[] {
+export function buildComplexity(d: InsightsData, days: number, now = Date.now(), limit = 200): ComplexityPoint[] {
   const from = cutoff(days, now);
 
   const results: ComplexityPoint[] = [];
@@ -376,14 +377,14 @@ export function buildComplexity(d: InsightsData, days: number, now = Date.now())
 
   return results
     .sort((a, b) => b.effectiveTokens - a.effectiveTokens)
-    .slice(0, 200);
+    .slice(0, limit);
 }
 
 // ---------------------------------------------------------------------------
 // buildYield
 // ---------------------------------------------------------------------------
 
-export function buildYield(d: InsightsData, days: number, now = Date.now()) {
+export function buildYield(d: InsightsData, days: number, now = Date.now(), limit = 10) {
   const from = cutoff(days, now);
 
   let committed = 0;
@@ -421,7 +422,7 @@ export function buildYield(d: InsightsData, days: number, now = Date.now()) {
     rate: total > 0 ? committed / total : 0,
     topUncommitted: topUncommitted
       .sort((a, b) => b.effectiveTokens - a.effectiveTokens)
-      .slice(0, 10),
+      .slice(0, limit),
   };
 }
 
@@ -512,7 +513,7 @@ export interface FileChurnEntry {
   lastTs: number;
 }
 
-export function buildFileChurn(d: InsightsData, days: number, now = Date.now()) {
+export function buildFileChurn(d: InsightsData, days: number, now = Date.now(), limit = 25) {
   const from = cutoff(days, now);
   const map = new Map<string, { path: string; edits: number; lastTs: number; projectPath: string }>();
   for (const tc of d.toolCalls) {
@@ -535,7 +536,7 @@ export function buildFileChurn(d: InsightsData, days: number, now = Date.now()) 
       lastTs: v.lastTs,
     }))
     .sort((a, b) => b.edits - a.edits)
-    .slice(0, 25);
+    .slice(0, limit);
   const totalEdits = [...map.values()].reduce((s, v) => s + v.edits, 0);
   return { totalEdits, uniqueFiles: map.size, files };
 }

--- a/server/workflows.ts
+++ b/server/workflows.ts
@@ -39,6 +39,9 @@ export interface WorkflowAgentInfo {
   lastToolName?: string;
 }
 
+/** How a run's cost was priced — `per-agent` is materially more accurate. */
+export type WorkflowCostBasis = 'per-agent' | 'blended-run';
+
 export interface WorkflowRun {
   runId: string;
   name: string;
@@ -55,6 +58,8 @@ export interface WorkflowRun {
   agentCount: number;
   runningAgents: number;
   tokens: number;
+  cost: number; // estimated equivalent-API cost
+  costBasis: WorkflowCostBasis;
   toolCalls: number;
   defaultModel: string;
   project: string;
@@ -65,6 +70,21 @@ export interface WorkflowRun {
 export interface WorkflowsData {
   live: WorkflowRun[];
   recent: WorkflowRun[];
+}
+
+/** Path-free row safe to hand to the UI or a model. */
+export interface WorkflowRunSummary {
+  name: string;
+  project: string;
+  status: 'completed' | 'failed' | 'unknown';
+  tokens: number;
+  cost: number;
+  costBasis: WorkflowCostBasis;
+  agentCount: number;
+  toolCalls: number;
+  durationMs: number;
+  startedAt: number;
+  defaultModel: string;
 }
 
 /** All-time aggregate over every final workflow journal on disk. */
@@ -80,6 +100,27 @@ export interface WorkflowStats {
   estCostUsd: number; // rough blended equivalent-API estimate
   totalToolCalls: number;
   busiestDay: { day: number; count: number } | null; // day = local-midnight ms
+  topRunsByCost: WorkflowRunSummary[]; // all-time, cost desc — `recent` only covers 90d/200 runs
+  recentRuns: WorkflowRunSummary[]; // all-time, newest first — same rows, no full journal parse
+}
+
+/**
+ * Price a run per-subagent when `agents` actually covers it, else fall back to one
+ * blended rate for the whole run. `agents` is capped (RECENT_AGENT_CAP / LIVE_AGENT_PARSE),
+ * so only trust the per-agent sum when the cap did not bite.
+ */
+export function computeRunCost(
+  tokens: number,
+  defaultModel: string,
+  agents: WorkflowAgentInfo[],
+): { cost: number; costBasis: WorkflowCostBasis } {
+  const agentTokens = agents.reduce((s, a) => s + a.tokens, 0);
+  if (agents.length > 0 && tokens > 0 && agentTokens >= tokens * 0.9) {
+    let cost = 0;
+    for (const a of agents) cost += (a.tokens / 1_000_000) * blendedRatePerMillion(a.model || defaultModel);
+    return { cost, costBasis: 'per-agent' };
+  }
+  return { cost: (tokens / 1_000_000) * blendedRatePerMillion(defaultModel), costBasis: 'blended-run' };
 }
 
 // ── Tunables ─────────────────────────────────────────────────────────────────
@@ -408,6 +449,7 @@ async function buildLiveRun(d: DiscoveredDir, probe: DirProbe): Promise<Workflow
     agentCount,
     runningAgents,
     tokens,
+    ...computeRunCost(tokens, defaultModel, agents),
     toolCalls: 0, // not tracked incrementally for live runs
     defaultModel,
     project,
@@ -461,6 +503,8 @@ async function parseFinalJournalUncached(j: DiscoveredJournal): Promise<Workflow
       agentCount: 0,
       runningAgents: 0,
       tokens: 0,
+      cost: 0,
+      costBasis: 'blended-run',
       toolCalls: 0,
       defaultModel: 'inherit',
       project,
@@ -503,6 +547,7 @@ async function parseFinalJournalUncached(j: DiscoveredJournal): Promise<Workflow
 
   const tokens =
     num(o.totalTokens) > 0 ? num(o.totalTokens) : agentEntries.reduce((s, a) => s + num(a.tokens), 0);
+  const defaultModel = String(o.defaultModel || 'inherit');
   const lastActivity = Date.parse(o.timestamp) || j.mtime;
   const logs: string[] = Array.isArray(o.logs) ? o.logs.filter((l: any) => typeof l === 'string') : [];
 
@@ -524,8 +569,9 @@ async function parseFinalJournalUncached(j: DiscoveredJournal): Promise<Workflow
     agentCount: num(o.agentCount) || agentEntries.length,
     runningAgents: 0,
     tokens,
+    ...computeRunCost(tokens, defaultModel, agents),
     toolCalls: num(o.totalToolCalls) || agentEntries.reduce((s, a) => s + num(a.toolCalls), 0),
-    defaultModel: String(o.defaultModel || 'inherit'),
+    defaultModel,
     project,
     resultStats: extractStats(o.result),
     logsTail: logs.slice(-8),
@@ -576,6 +622,8 @@ async function computeWorkflows(): Promise<WorkflowsData> {
 // the all-time stats aggregate. Memoized by (path, mtime); journals are write-once
 // so the cache is effectively permanent after first warm-up.
 interface JournalSummary {
+  name: string;
+  project: string;
   status: 'completed' | 'failed' | 'unknown';
   startedAt: number;
   durationMs: number;
@@ -590,7 +638,10 @@ const summaryCache = new Map<string, { mtime: number; summary: JournalSummary }>
 async function peekSummary(j: DiscoveredJournal): Promise<JournalSummary> {
   const cached = summaryCache.get(j.path);
   if (cached && cached.mtime === j.mtime) return cached.summary;
+  const project = projectNameFromPath(projectPathFromFile(j.path));
   let summary: JournalSummary = {
+    name: j.runId,
+    project,
     status: 'unknown',
     startedAt: j.mtime,
     durationMs: 0,
@@ -606,6 +657,8 @@ async function peekSummary(j: DiscoveredJournal): Promise<JournalSummary> {
       const agentEntries = wp.filter((x) => x?.type === 'workflow_agent');
       const lastActivity = Date.parse(o.timestamp) || j.mtime;
       summary = {
+        name: String(o.workflowName || basename(o.scriptPath || '').replace(`-${j.runId}.js`, '') || j.runId),
+        project,
         status: o.status === 'completed' ? 'completed' : o.status ? 'failed' : 'unknown',
         startedAt: num(o.startTime) || lastActivity,
         durationMs: num(o.durationMs),
@@ -643,6 +696,7 @@ async function computeWorkflowStats(): Promise<WorkflowStats> {
   let estCostUsd = 0;
   const modelFreq = new Map<string, number>();
   const dayFreq = new Map<number, number>();
+  const rows: WorkflowRunSummary[] = [];
 
   for (const s of summaries) {
     if (s.status === 'completed') completed++;
@@ -654,7 +708,24 @@ async function computeWorkflowStats(): Promise<WorkflowStats> {
       durSum += s.durationMs;
       durCount++;
     }
-    estCostUsd += (s.tokens / 1_000_000) * blendedRatePerMillion(s.defaultModel);
+    // The summary carries no per-agent models, so every all-time row is necessarily
+    // priced `blended-run`. Route it through computeRunCost so the scalar total and
+    // the rows can never drift apart.
+    const { cost, costBasis } = computeRunCost(s.tokens, s.defaultModel, []);
+    estCostUsd += cost;
+    rows.push({
+      name: s.name,
+      project: s.project,
+      status: s.status,
+      tokens: s.tokens,
+      cost,
+      costBasis,
+      agentCount: s.agentCount,
+      toolCalls: s.toolCalls,
+      durationMs: s.durationMs,
+      startedAt: s.startedAt,
+      defaultModel: s.defaultModel,
+    });
     if (s.defaultModel && s.defaultModel !== 'inherit') {
       modelFreq.set(s.defaultModel, (modelFreq.get(s.defaultModel) ?? 0) + 1);
     }
@@ -681,6 +752,8 @@ async function computeWorkflowStats(): Promise<WorkflowStats> {
     estCostUsd,
     totalToolCalls,
     busiestDay,
+    recentRuns: [...rows].sort((a, b) => b.startedAt - a.startedAt).slice(0, 10),
+    topRunsByCost: rows.sort((a, b) => b.cost - a.cost).slice(0, 10),
   };
 }
 

--- a/src/components/design-system/organisms/AiChat/AiChat.tsx
+++ b/src/components/design-system/organisms/AiChat/AiChat.tsx
@@ -2,13 +2,21 @@ import { useEffect, useRef, useState } from 'react';
 import { useAiChat } from '@/hooks/useAiChat';
 import { PROVIDER_MODELS } from '@/hooks/useAiConfig';
 import { Markdown } from '@/components/design-system/atoms/Markdown/Markdown';
+import { ToggleGroup } from '@/components/design-system/atoms/ToggleGroup/ToggleGroup';
 import type { AiChatProps } from './types';
 
 const SUGGESTIONS = [
-  'Which project costs the most?',
-  'Am I retrying edits too much?',
+  'Which workflow cost me the most?',
   "What's my error-rate trend?",
-  'Which model should I use less?',
+  'Which project costs the most?',
+  'Am I close to my weekly limit?',
+];
+
+type DayOption = '7' | '30' | '90';
+const DAY_OPTIONS: { value: DayOption; label: string }[] = [
+  { value: '7', label: '7d' },
+  { value: '30', label: '30d' },
+  { value: '90', label: '90d' },
 ];
 
 const BACKEND_NOTE: Record<string, string> = {
@@ -18,13 +26,14 @@ const BACKEND_NOTE: Record<string, string> = {
   none: '',
 };
 
-export function AiChat({ status, config, onChangeConfig, onAsked, onOpenSettings }: AiChatProps) {
+export function AiChat({ status, config, source, onChangeConfig, onAsked, onOpenSettings }: AiChatProps) {
   const { messages, loading, suggestions, send, reset } = useAiChat();
   const modelOptions = (() => {
     const list = PROVIDER_MODELS[config.provider] ?? [];
     return list.includes(config.model) ? list : [config.model, ...list];
   })();
   const [input, setInput] = useState('');
+  const [days, setDays] = useState<DayOption>('30');
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -37,7 +46,7 @@ export function AiChat({ status, config, onChangeConfig, onAsked, onOpenSettings
   function ask(q: string) {
     if (!q.trim() || loading) return;
     onAsked();
-    send(q, config);
+    send(q, config, { source, days: Number(days) });
     setInput('');
   }
 
@@ -62,6 +71,16 @@ export function AiChat({ status, config, onChangeConfig, onAsked, onOpenSettings
       <div className="mb-3 flex items-center justify-between">
         <h2 className="flex items-center gap-2 text-sm font-semibold text-zinc-300">✨ AI Insights</h2>
         <div className="flex items-center gap-3">
+          <ToggleGroup<DayOption> options={DAY_OPTIONS} value={days} onChange={setDays} />
+          <a
+            href={`/api/ai/context?days=${days}&source=${source}`}
+            target="_blank"
+            rel="noreferrer"
+            title="The exact JSON the chat sends to the model"
+            className="text-[11px] text-zinc-600 transition-colors hover:text-zinc-400"
+          >
+            What the AI can see
+          </a>
           {config.apiKey ? (
             <select
               value={config.model}
@@ -111,8 +130,8 @@ export function AiChat({ status, config, onChangeConfig, onAsked, onOpenSettings
             </div>
           </div>
         ) : (
-          messages.map((m, i) => (
-            <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+          messages.map((m) => (
+            <div key={m.id} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
               <div
                 className={`max-w-[80%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed ${
                   m.role === 'user'
@@ -124,7 +143,12 @@ export function AiChat({ status, config, onChangeConfig, onAsked, onOpenSettings
               >
                 {m.role === 'assistant' && !m.error ? (
                   m.content ? (
-                    <Markdown text={m.content} />
+                    <>
+                      <Markdown text={m.content} />
+                      {m.datasets && m.datasets.length > 0 && (
+                        <p className="mt-2 text-[10px] text-zinc-600">Answered from: overview + {m.datasets.join(', ')}</p>
+                      )}
+                    </>
                   ) : (
                     <span className="text-zinc-500">
                       <span className="pulse-dot mr-1.5" />

--- a/src/components/design-system/organisms/AiChat/types.ts
+++ b/src/components/design-system/organisms/AiChat/types.ts
@@ -1,8 +1,11 @@
 import type { AiConfig, AiStatus } from '@/types';
+import type { SourceFilter } from '@/hooks/useSource';
 
 export interface AiChatProps {
   status: AiStatus | null;
   config: AiConfig;
+  /** Surface the header toggle is on — the chat answers over the same one. */
+  source: SourceFilter;
   /** Persist a config change (e.g. model picked from the chat header). */
   onChangeConfig: (c: AiConfig) => void;
   onAsked: () => void;

--- a/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
+++ b/src/components/design-system/organisms/WorkflowsView/WorkflowsView.tsx
@@ -3,7 +3,7 @@ import { Section } from '@/components/design-system/molecules/Section/Section';
 import { InfoTip } from '@/components/design-system/atoms/InfoTip/InfoTip';
 import { Skeleton } from '@/components/design-system/atoms/Skeleton/Skeleton';
 import type { StatCardProps } from '@/components/design-system/atoms/StatCard/types';
-import { compact, usd, shortModel, dayLabel } from '@/lib/format';
+import { compact, usd, shortModel, dayLabel, timeAgoOrDate } from '@/lib/format';
 import { modelColor } from '@/lib/palette';
 import { useConfigMode } from '@/hooks/useConfigMode';
 import { elapsedSec, formatElapsed, displayModel } from '@/components/design-system/organisms/AgentActivity/utils';
@@ -262,7 +262,7 @@ const STATUS_PILL: Record<WorkflowRun['status'], string> = {
 
 function RecentWorkflowRow({ run }: WorkflowCardProps) {
   const [open, setOpen] = useState(false);
-  const ago = formatElapsed(elapsedSec(run.lastActivity));
+  const when = timeAgoOrDate(run.lastActivity);
   const hasDetail = run.agents.length > 0 || (run.logsTail?.length ?? 0) > 0;
   const showModel = run.defaultModel && run.defaultModel !== 'inherit' && run.defaultModel !== 'unknown';
   return (
@@ -276,7 +276,7 @@ function RecentWorkflowRow({ run }: WorkflowCardProps) {
         <span className={`flex-none rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${STATUS_PILL[run.status]}`}>
           {run.status}
         </span>
-        <span className="flex-none font-mono text-[11px] text-zinc-600">{ago} ago</span>
+        <span className="flex-none font-mono text-[11px] text-zinc-600">{when}</span>
       </div>
       {run.summary && run.summary !== run.name && (
         <p className="truncate text-xs text-zinc-500" title={run.summary}>{run.summary}</p>
@@ -286,6 +286,18 @@ function RecentWorkflowRow({ run }: WorkflowCardProps) {
         <span>{formatElapsed(Math.floor(run.durationMs / 1000))}</span>
         <span>{run.agentCount} agents</span>
         <span>{compact(run.tokens)} tok</span>
+        {run.cost > 0 && (
+          <span
+            className="text-amber-500/70"
+            title={
+              run.costBasis === 'per-agent'
+                ? 'Estimated equivalent-API cost, priced per subagent model.'
+                : 'Estimated equivalent-API cost at one blended rate for the whole run — coarse.'
+            }
+          >
+            ~{usd(run.cost)}
+          </span>
+        )}
         {run.toolCalls > 0 && <span>{run.toolCalls} tool calls</span>}
         {run.phaseTotal != null && <span>{run.phaseTotal} phases</span>}
         {hasDetail && (

--- a/src/components/tabs/AiTab/AiTab.tsx
+++ b/src/components/tabs/AiTab/AiTab.tsx
@@ -1,15 +1,25 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AiChat } from '@/components/design-system/organisms/AiChat/AiChat';
 import { useAiInsightCtx } from '@/hooks/useAiInsightContext';
+import { useSource } from '@/hooks/useSource';
 import { track } from '@/lib/analytics';
 
 export function AiTab() {
   const navigate = useNavigate();
   const { aiStatus, aiConfig, setAiConfig } = useAiInsightCtx();
+  const { source } = useSource();
+
+  // Warm the aggregate caches so the first question doesn't pay for a cold scan.
+  useEffect(() => {
+    void fetch(`/api/ai/context?source=${source}`).catch(() => {});
+  }, [source]);
+
   return (
     <AiChat
       status={aiStatus.data ?? null}
       config={aiConfig}
+      source={source}
       onChangeConfig={setAiConfig}
       onAsked={() => track('ai_chat_asked')}
       onOpenSettings={() => navigate('/settings')}

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -1,11 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AiConfig } from '../types';
+import type { SourceFilter } from './useSource';
 
 export interface ChatMessage {
+  id: string;
   role: 'user' | 'assistant';
   content: string;
   ts: number;
   error?: boolean;
+  /** Which datasets the backend routed this answer to (X-AI-Datasets), for the footnote. */
+  datasets?: string[];
+}
+
+/** The window + surface the chat answers over — mirrors what the user is looking at. */
+export interface AiScope {
+  source: SourceFilter;
+  days: number;
 }
 
 const STORE_KEY = 'claude-dashboard-ai-chat-v1';
@@ -16,7 +26,9 @@ function loadMessages(): ChatMessage[] {
     const raw = localStorage.getItem(STORE_KEY);
     if (!raw) return [];
     const a = JSON.parse(raw);
-    return Array.isArray(a) ? a : [];
+    if (!Array.isArray(a)) return [];
+    // transcripts persisted before `id` existed get one backfilled on load
+    return (a as ChatMessage[]).map((m) => (m.id ? m : { ...m, id: crypto.randomUUID() }));
   } catch {
     return [];
   }
@@ -34,6 +46,7 @@ export function useAiChat() {
   const [loading, setLoading] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const abort = useRef<AbortController | null>(null);
+  const sending = useRef(false); // synchronous re-entrancy guard — `loading` state lags a fast double-click
 
   useEffect(() => {
     try {
@@ -46,12 +59,12 @@ export function useAiChat() {
   // Ask the model for conversation-aware follow-up chips. Best-effort: failures
   // just leave the static fallback suggestions in place.
   const fetchSuggestions = useCallback(
-    async (history: Turn[], config: AiConfig | undefined, ac: AbortController) => {
+    async (history: Turn[], config: AiConfig | undefined, scope: AiScope, ac: AbortController) => {
       try {
         const res = await fetch('/api/ai/suggestions', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ history, config: config?.apiKey ? config : undefined }),
+          body: JSON.stringify({ history, ...scope, config: config?.apiKey ? config : undefined }),
           signal: ac.signal,
         });
         if (!res.ok) return;
@@ -66,16 +79,16 @@ export function useAiChat() {
   );
 
   const send = useCallback(
-    async (question: string, config?: AiConfig) => {
+    async (question: string, config: AiConfig | undefined, scope: AiScope) => {
       const q = question.trim();
-      if (!q || loading) return;
-      const history = messages.filter((m) => !m.error).map((m) => ({ role: m.role, content: m.content }));
-      const assistantTs = Date.now() + 1; // distinct from the user message ts
-      setMessages((m) => [
-        ...m,
-        { role: 'user', content: q, ts: Date.now() },
-        { role: 'assistant', content: '', ts: assistantTs },
-      ]);
+      if (!q || sending.current) return;
+      sending.current = true;
+      // an empty assistant turn is garbage context — never send it back to the model
+      const history = messages.filter((m) => !m.error && m.content).map((m) => ({ role: m.role, content: m.content }));
+      const now = Date.now(); // hoisted: the setMessages updater must stay pure (StrictMode double-invokes it)
+      const user: ChatMessage = { id: crypto.randomUUID(), role: 'user', content: q, ts: now };
+      const assistant: ChatMessage = { id: crypto.randomUUID(), role: 'assistant', content: '', ts: now + 1 };
+      setMessages((m) => [...m, user, assistant]);
       setLoading(true);
       setSuggestions([]); // clear stale chips while the next answer streams
       abort.current?.abort();
@@ -85,7 +98,7 @@ export function useAiChat() {
       const patchAssistant = (fn: (a: ChatMessage) => ChatMessage) =>
         setMessages((m) => {
           const c = [...m];
-          const i = c.findIndex((x) => x.role === 'assistant' && x.ts === assistantTs);
+          const i = c.findIndex((x) => x.id === assistant.id);
           if (i >= 0) c[i] = fn(c[i]);
           return c;
         });
@@ -94,7 +107,7 @@ export function useAiChat() {
         const res = await fetch('/api/ai/chat', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ question: q, history, config: config?.apiKey ? config : undefined }),
+          body: JSON.stringify({ question: q, history, ...scope, config: config?.apiKey ? config : undefined }),
           signal: ac.signal,
         });
         if (!res.ok) {
@@ -107,6 +120,10 @@ export function useAiChat() {
           }
           throw new Error(msg);
         }
+        // Which datasets the router pulled — the only way to see why an answer
+        // came out the way it did (there is no HMR and no test suite here).
+        const routed = (res.headers.get('X-AI-Datasets') ?? '').split(',').filter(Boolean);
+        if (routed.length > 0) patchAssistant((a) => ({ ...a, datasets: routed }));
         const reader = res.body?.getReader();
         if (!reader) throw new Error('No response stream');
         const dec = new TextDecoder();
@@ -126,17 +143,22 @@ export function useAiChat() {
           patchAssistant((a) => ({ ...a, content: 'Empty response from the model.', error: true }));
         } else {
           const finalHistory: Turn[] = [...history, { role: 'user', content: q }, { role: 'assistant', content: acc }];
-          void fetchSuggestions(finalHistory, config, ac);
+          void fetchSuggestions(finalHistory, config, scope, ac);
         }
       } catch (e) {
-        if ((e as { name?: string })?.name === 'AbortError') return;
+        if ((e as { name?: string })?.name === 'AbortError') {
+          // drop the orphaned bubble — an empty assistant message renders as a stuck "thinking…"
+          setMessages((m) => m.filter((x) => x.id !== assistant.id || x.content));
+          return;
+        }
         const msg = e instanceof Error ? e.message : String(e);
         patchAssistant((a) => ({ ...a, content: msg, error: true }));
       } finally {
+        sending.current = false;
         setLoading(false);
       }
     },
-    [messages, loading, fetchSuggestions],
+    [messages, fetchSuggestions],
   );
 
   const reset = useCallback(() => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -40,6 +40,17 @@ export function ago(ms: number): string {
   return `${Math.round(m / 60)}h ago`;
 }
 
+/** Relative inside 24h, absolute date+time beyond it — "385h ago" is unreadable. */
+export function timeAgoOrDate(ms: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m ago`;
+  return dateTimeLabel(ms);
+}
+
 export function untilLabel(ms: number): string {
   const s = Math.max(0, Math.round((ms - Date.now()) / 1000));
   const h = Math.floor(s / 3600);

--- a/src/types.ts
+++ b/src/types.ts
@@ -432,6 +432,9 @@ export interface WorkflowAgentInfo {
   lastToolName?: string;
 }
 
+/** How a run's cost was priced — `per-agent` is materially more accurate. */
+export type WorkflowCostBasis = 'per-agent' | 'blended-run';
+
 export interface WorkflowRun {
   runId: string;
   name: string;
@@ -448,6 +451,8 @@ export interface WorkflowRun {
   agentCount: number;
   runningAgents: number;
   tokens: number;
+  cost: number; // estimated equivalent-API cost
+  costBasis: WorkflowCostBasis;
   toolCalls: number;
   defaultModel: string;
   project: string;
@@ -458,6 +463,21 @@ export interface WorkflowRun {
 export interface WorkflowsData {
   live: WorkflowRun[];
   recent: WorkflowRun[];
+}
+
+/** Path-free row safe to hand to the UI or a model. */
+export interface WorkflowRunSummary {
+  name: string;
+  project: string;
+  status: 'completed' | 'failed' | 'unknown';
+  tokens: number;
+  cost: number;
+  costBasis: WorkflowCostBasis;
+  agentCount: number;
+  toolCalls: number;
+  durationMs: number;
+  startedAt: number;
+  defaultModel: string;
 }
 
 /** All-time aggregate over every final workflow journal on disk (`/api/workflows/stats`). */
@@ -473,6 +493,8 @@ export interface WorkflowStats {
   estCostUsd: number; // rough blended equivalent-API estimate
   totalToolCalls: number;
   busiestDay: { day: number; count: number } | null; // day = local-midnight ms
+  topRunsByCost: WorkflowRunSummary[]; // all-time, cost desc — `recent` only covers 90d/200 runs
+  recentRuns: WorkflowRunSummary[]; // all-time, newest first — same rows, no full journal parse
 }
 
 // ── AI Insights ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Asking the AI Insights chat *"what workflow cost me the most, and how many tokens did I use there?"* answered about a **project**, claimed **"the usage data doesn't break things down by workflow"**, and tacked on a nonsense caveat that the project's cost exceeded the whole-account weekly total.

Three separate bugs, none of them the model's fault:

1. **The chat was single-shot over a hand-picked ~1KB blob.** `buildAiContext()` sent 6 models, 10 tools, 8 projects and 9 scalars — that was the model's *entire universe*. No workflows, no live limits, no sessions, no trends. The denial was true from where it stood, and "workflow" collapsed onto the nearest visible thing: a project.
2. **Per-run workflow cost did not exist anywhere in the codebase.** `WorkflowRun` had `tokens` but no `cost`. Even a perfect model could not have answered.
3. **The bogus caveat was a hard-coded window mismatch** — account totals were built over 7 days, project costs over 30, and the JSON declared `window: {weeklyDays: 7}` for both. The model correctly noticed the numbers didn't reconcile and reported it.

~20 endpoints were invisible to the chat, including the shipped suggestion chip *"What's my error-rate trend?"* — only the scalar `errorRate` was ever sent, never `errors.trend[]`.

## What changed

The chat now receives an **overview** (one window, one surface — so every number is comparable), a **catalog of all 17 datasets** flagged loaded/not, and the **detail blocks a lexical-first router pulls** for the question actually asked.

**No `tool_use`.** `resolveBackend()` ranks the `claude --print` CLI *above* the OAuth path, and that backend has no tool channel at all — an agentic loop would be dead by default on the most common backend. The router degrades instead: lexical hit (zero extra model calls, works everywhere) → cheap model call on API backends → overview only. It can never fail the chat, and `server/ai.ts` is untouched.

The **catalog** is the load-bearing piece: it makes *"the dashboard doesn't track that"* structurally unsayable about something it does track. A retrieval miss becomes *"I do track workflow runs — ask me about workflows."*

### Truncation is now honest

Five insights builders pre-clipped their own output (branches→10, churn→25, `errors.perTool`→12), so a naive `shown/total` wrapper would have reported `truncated: false` on a list that *was* truncated — recreating the exact hallucination it was meant to prevent. They now take an optional `limit` defaulting to today's cap (every existing route stays byte-identical); the AI path passes `Infinity` and applies its own `topN()`, carrying `sortedBy / shown / total / truncated` plus an `other` rollup so partial lists still reconcile against the total.

### Privacy

`server/ai-datasets.ts` is the boundary and projects an **explicit allowlist** — it never spreads a builder's return. `scrubForModel` is a key-name blocklist and cannot strip a path embedded *inside a string value* (`logsTail` is raw stdout; `summary`/`phases`/`resultStats` are free text from a generated script), so none of those fields enter a dataset. Branch and file names reach a **local** Claude backend; an OpenAI/Gemini key gets `{redacted}`.

### Also fixed

- **Duplicate chat bubble + stuck "thinking…"** — a stale `loading` guard let a fast double-click double-send; the second send aborted the first, and the `AbortError` path returned *without* patching, orphaning an empty assistant bubble that rendered as a permanent "thinking…" and persisted to `localStorage`.
- **`385h 0m ago`** on the Workflows tab — an absolute timestamp was being fed to `formatElapsed()`, a *duration* formatter whose largest unit is hours, so it never rolled into days.

## Verified end-to-end (Docker, against real data)

The exact question that failed:

> The most expensive workflow (all-time, Claude Code only) was **deep-research** at an estimated **$48.96**, using **4,450,914 effective tokens** across 110 subagents. Note there are two runs tied at that exact figure…

`X-AI-Route: lexical` · `X-AI-Datasets: workflows` · `X-AI-Backend: cli`

| Check | Result |
|---|---|
| The reported question | Names the run, estimated cost, token count, all-time framing |
| `"What's my error-rate trend?"` (shipped chip) | Now cites day-over-day movement from `dailyTrend` — was unanswerable |
| Window regression | Project cost ($1,943.87) now sits *under* the account total ($3,211.45); same window by construction |
| Truncation | *"this is the top 20 of 1,085 — the rest roll up into 2,887 edits… I can't call this the complete list"* |
| Leak check on `/api/ai/context` | No `path` / `cwd` / `sessionId` / `runId` / `logsTail` / `firstPrompt` |
| Redaction | Local backend sees 34 branches / 1,085 files; third-party key gets `{redacted}` |
| Payload assembly | **73ms warm** (reuses the dashboard's memoized aggregates) |

**Perf defect caught during verification:** the first cut called `getWorkflows()`, which takes **~8s** on a real history — the 1.5s guard was silently blanking the recent-runs list on every turn. Rerouted through `getWorkflowStats()` (~0.4s), which reads *every* journal rather than just the last 90 days. Better data, 20× faster.

> Note: the cold JSONL scan (14–26s) is pre-existing and hits every route — `/api/projects` takes 26s too. The AI tab now pings `/api/ai/context` on mount so the first question doesn't pay for it.

## Sequence

```mermaid
sequenceDiagram
    participant U as User
    participant C as AiChat
    participant R as ai-router
    participant D as ai-datasets
    participant P as ai-context
    participant M as Model

    U->>C: "what workflow cost me the most?"
    C->>R: POST /api/ai/chat {question, days, source}
    R->>R: lexicalRoute() → ["workflows"]
    Note over R: hit → zero extra model calls,<br/>works on the no-tool CLI backend
    R->>D: loadDatasets(["workflows"])
    D->>D: getWorkflowStats() — allowlist projection
    D-->>P: topRunsByCost + recentRuns + caveats
    P->>P: overview (one window) + catalog + notes
    P->>M: system + payload (scrubbed)
    M-->>U: "deep-research, ~$48.96, 4,450,914 tokens"
    Note over C: X-AI-Route: lexical<br/>X-AI-Datasets: workflows
```

## Notes for review

- `npx tsc -b` clean (repo has no tests/linter — that's the bar).
- New env knobs: `AI_ROUTER=auto|model|lexical|off`, `AI_DATASETS_DISABLED=1`, `AI_MAX_DETAIL_BYTES`.
- New route `GET /api/ai/context` doubles as the **privacy disclosure** — you can read the exact JSON the chat would send before sending it (wired to a "What the AI can see" link in the chat header).
- The `memoBuilder` keys are deliberately shared with `index.ts`'s bare names. Two rules keep them interchangeable: **event** builders are called with `now = computedAt`; **insights** builders are called *without* `now`. Breaking either would silently poison the dashboard's own route cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
