### PR TITLE
feat: add Claude Opus 5 to the model tables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,8 @@ CLAUDE_DIR_HOST=C:/Users/you/.claude
 #ANTHROPIC_BASE_URL=https://litellm.company.com
 #ANTHROPIC_AUTH_TOKEN=sk-litellm-...
 #
-# Optional model override for the server-side fallback (default claude-opus-4-8).
-# Set this if your proxy doesn't serve claude-opus-4-8 (else calls 400/404):
+# Optional model override for the server-side fallback (default claude-opus-5).
+# Set this if your proxy doesn't serve claude-opus-5 (else calls 400/404):
 #AI_MODEL=claude-sonnet-4-6
 
 # OPTIONAL — "Actual billed" cost from a LiteLLM gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.24] - 2026-07-24
+
+### Added
+- Added Claude Opus 5 to the model tables for improved pricing accuracy.
+
+### Changed
+- Updated pricing logic to correctly identify Opus 5 without legacy billing.
+- Adjusted amber color code for Opus 5, enhancing visual accessibility in light and dark modes.
+- Modified the PRICING_DATA to reflect Opus 5 as the newest popular model.
+- Updated default model tracking to include Opus 5 in AI Insights configuration.
+- Reflected Opus 5 updates in example environment configuration and documentation.
+
 ## [0.1.23] - 2026-07-21
 
 ### Added
@@ -287,6 +299,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live-API fallback to the local logs when there is no active block
   (`resets_at = null`).
 
+[0.1.24]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.24
 [0.1.23]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.23
 [0.1.22]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.22
 [0.1.21]: https://github.com/iftahs/claude-dashboard/releases/tag/v0.1.21

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ The AI Insights tab and the per-section "✨ AI" buttons call a model **only whe
 
 - **What's *never* sent:** transcripts or message contents, full file/project paths, session IDs, or your OAuth token.
 - **Which backend serves the call** (first available wins): an API key you set in **⚙ Settings → AI Insights** (Claude / OpenAI / Gemini, stored only in your browser) → a server-side `ANTHROPIC_API_KEY` → the local `claude` CLI (`claude -p`, uses your subscription) → your Claude.ai OAuth token → otherwise the feature shows setup instructions and does nothing.
-- **Server-side defaults** for Docker/self-host live in [`.env.example`](.env.example): `WITH_CLAUDE_CLI=1`, `ANTHROPIC_API_KEY`, and `AI_MODEL` (default `claude-opus-4-8`).
+- **Server-side defaults** for Docker/self-host live in [`.env.example`](.env.example): `WITH_CLAUDE_CLI=1`, `ANTHROPIC_API_KEY`, and `AI_MODEL` (default `claude-opus-5`).
 - If you never open the AI tab or click "✨ AI", **no aggregates are ever sent.**
 
 ## Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,11 @@ services:
       # AI Insights (chat + per-section buttons). In Docker there's no `claude`
       # CLI, so set ANTHROPIC_API_KEY in .env for a dedicated, un-throttled
       # backend. Unset → falls back to the Claude.ai OAuth token (works, but is
-      # rate-limited → may 429). AI_MODEL is optional (default claude-opus-4-8).
+      # rate-limited → may 429). AI_MODEL is optional (default claude-opus-5).
       # To route through a corporate LLM proxy (LiteLLM / gateway) instead, set
       # ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN in .env (the token is sent as a
       # bearer Authorization header). Host shell vars are NOT auto-passed, so they
-      # must be listed here. Set AI_MODEL if the proxy doesn't serve claude-opus-4-8.
+      # must be listed here. Set AI_MODEL if the proxy doesn't serve claude-opus-5.
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
       - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "license": "MIT",
       "dependencies": {
         "@posthog/react": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-dashboard",
   "private": false,
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "description": "Beautiful local dashboard for Claude Code usage — 5-hour blocks, weekly trends, model breakdown, tool usage and an activity heatmap, read straight from your ~/.claude logs.",
   "license": "MIT",

--- a/server/ai.ts
+++ b/server/ai.ts
@@ -40,7 +40,7 @@ export class AiUnavailableError extends Error {}
 export class AiTokenRejectedError extends Error {}
 export class AiCallError extends Error {}
 
-const DEFAULT_MODEL = process.env.AI_MODEL || 'claude-opus-4-8';
+const DEFAULT_MODEL = process.env.AI_MODEL || 'claude-opus-5';
 const CALL_TIMEOUT_MS = Number(process.env.AI_TIMEOUT_MS || 60_000);
 const MAX_OUTPUT_TOKENS = 1024;
 const CLI_PROBE_TTL = 5 * 60_000;

--- a/server/pricing.ts
+++ b/server/pricing.ts
@@ -12,8 +12,9 @@ const TABLE: Array<[RegExp, Price]> = [
   [/fable/i, { input: 10, output: 50, cacheWrite: 12.50, cacheRead: 1.0 }],
   // Claude Mythos
   [/mythos/i, { input: 10, output: 50, cacheWrite: 12.50, cacheRead: 1.0 }],
-  // Claude Opus: 4.5, 4.6, 4.7, 4.8 are priced at 5 / 25
-  [/opus-4-[5-8]|opus-4\.[5-8]/i, { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 }],
+  // Claude Opus: 5 and 4.5–4.8 are priced at 5 / 25. Must precede the bare /opus/i
+  // row below — a new opus added after it would silently bill at legacy 15 / 75.
+  [/opus-5|opus-4-[5-8]|opus-4\.[5-8]/i, { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 }],
   // Legacy Claude Opus (3.0, 4.0, 4.1) priced at 15 / 75
   [/opus/i, { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 }],
   // Claude Sonnet (all versions: 3.0, 3.5, 4.5, 4.6, 5) priced at 3 / 15

--- a/src/components/design-system/organisms/CostCalculation/utils.ts
+++ b/src/components/design-system/organisms/CostCalculation/utils.ts
@@ -3,7 +3,8 @@ import type { ModelPrice } from './types';
 export const PRICING_DATA: ModelPrice[] = [
   { name: 'Claude Fable 5', family: 'fable', input: 10, output: 50, cacheWrite: 12.5, cacheRead: 1.0, popular: true },
   { name: 'Claude Mythos 5 (limited availability)', family: 'mythos', input: 10, output: 50, cacheWrite: 12.5, cacheRead: 1.0 },
-  { name: 'Claude Opus 4.8', family: 'opus-4-8', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5, popular: true },
+  { name: 'Claude Opus 5', family: 'opus-5', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5, popular: true },
+  { name: 'Claude Opus 4.8', family: 'opus-4-8', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
   { name: 'Claude Opus 4.7', family: 'opus-4-7', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
   { name: 'Claude Opus 4.6', family: 'opus-4-6', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
   { name: 'Claude Opus 4.5', family: 'opus-4-5', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },

--- a/src/hooks/useAiConfig.ts
+++ b/src/hooks/useAiConfig.ts
@@ -10,7 +10,7 @@ export const PROVIDER_LABELS: Record<AiProvider, string> = {
 };
 
 export const PROVIDER_MODELS: Record<AiProvider, string[]> = {
-  claude: ['claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  claude: ['claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
   openai: ['gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'o4-mini'],
   gemini: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'],
 };

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -21,14 +21,25 @@
  * floor band — which is legal only because identity never rests on color alone: every
  * chart with ≥2 series ships a legend and names the model in its tooltip. Keep that
  * pairing if you touch these values, and re-run the validator.
+ *
+ * The amber family is pinched and its steps run LIGHTER, never darker: dark mode's
+ * lightness band tops out at L 0.67 and #c98500 already sits at that ceiling, while
+ * every amber darker than it collapses onto sonnet green under deutan/protan
+ * (#a86a00 ΔE 2.3, #8f6300 ΔE 1.3 — at or below the palette's worst cross-family
+ * pair, #008300↔#b93b3f at 3.1). So each superseded opus generation steps up in
+ * lightness instead: #c98500 (0.65, in band) → #db9200 (0.716) → #eda100 (0.764).
+ * The two lighter steps exit the dark band and warn on light-mode contrast; that is
+ * the accepted trade, carried by the legend and tooltip. #db9200's worst
+ * cross-family separation is ΔE 8.9, well clear of the 3.1 floor.
  */
 const MODEL_TABLE: Array<[RegExp, string]> = [
   // Order matters: specific patterns before generic fallbacks, first match wins
   // (mirrors the TABLE in server/pricing.ts).
   [/fable/i, '#e5484d'], // red
   [/mythos/i, '#b93b3f'], // red, deeper step — same price tier as fable
-  [/opus-4-[5-8]|opus-4\.[5-8]/i, '#c98500'], // amber
-  [/opus/i, '#eda100'], // legacy opus (15/75) — brighter amber, it costs more
+  [/opus-5/i, '#c98500'], // amber — newest opus holds the family's canonical hue
+  [/opus-4-[5-8]|opus-4\.[5-8]/i, '#db9200'], // amber, lighter step — superseded by opus 5
+  [/opus/i, '#eda100'], // legacy opus (15/75) — brightest amber, it costs more
   [/sonnet-5/i, '#008300'], // green
   [/sonnet/i, '#199e70'], // older sonnets — green family, aqua step
   [/haiku-4/i, '#3987e5'], // blue


### PR DESCRIPTION
## What

**Claude Opus 5** — model ID `claude-opus-5` — is generally available and absent from every model table in this repo.

**Price tier: $5 / $25 per MTok** (cache write $6.25, cache read $0.50) — the same tier as Opus 4.5–4.8.

Sources: [models overview](https://platform.claude.com/docs/en/about-claude/models/overview.md) and [pricing](https://platform.claude.com/docs/en/about-claude/pricing.md). (Note: `docs/en/pricing.md` 404s; the pricing table lives at `docs/en/about-claude/pricing.md`, which is where the overview links.)

## Why it matters

The ID matched only the bare `/opus/i` fallback in `server/pricing.ts` and billed at **legacy-Opus $15/$75 — a 3× overstatement of every USD figure in the app.** Silent: no error, and nothing the typecheck can catch.

Verified after the change:

```
claude-opus-5                $5/$25   #c98500  "opus-5"
claude-opus-4-8              $5/$25   #db9200  "opus 4.8"
claude-opus-4-5-20251101     $5/$25   #db9200  "opus 4.5"
claude-opus-4-1-20250805     $15/$75  #eda100  "opus 4.1"
vertex_ai/claude-opus-5      $5/$25   #c98500
```

## Files touched

| File | Change |
|---|---|
| `server/pricing.ts` | `opus-5` added to the 5/25 regex row, **above** the bare `/opus/i` fallback — first match wins |
| `src/lib/palette.ts` | `opus-5` takes the family's canonical amber `#c98500`; Opus 4.5–4.8 steps aside to `#db9200` |
| `CostCalculation/utils.ts` | `PRICING_DATA` row at its price tier (after Mythos 5, before Opus 4.8); takes `popular: true` over from Opus 4.8, matching the "newest of each family is popular" pattern |
| `src/hooks/useAiConfig.ts` | Prepended to `PROVIDER_MODELS.claude` — index 0 is the client-side AI Insights default |
| `server/ai.ts` | `DEFAULT_MODEL` → `claude-opus-5` (newest GA Opus-tier; not Fable/Mythos, which price above it) |
| `.env.example`, `docker-compose.yml`, `README.md` | They name the default too |

`src/lib/format.ts` deliberately unchanged — `shortModel` already renders `claude-opus-5` as `opus-5`, the same as `sonnet-5` / `fable-5`. No novel version format, so the duplicate in `AgentActivity/utils.ts` stays untouched as well.

## Palette validation

The amber family is pinched between red and green, so its steps run **lighter, never darker**. Dark mode's lightness band tops out at L 0.67 and `#c98500` already sits at that ceiling; every amber darker than it collapses onto sonnet green `#008300` under deutan/protan:

```
#a86a00  worst-vs-any deutan ΔE 2.3  (vs #008300)
#b07a10  worst-vs-any deutan ΔE 2.5  (vs #008300)
#9c6b12  worst-vs-any deutan ΔE 2.8  (vs #008300)
#8f6300  worst-vs-any deutan ΔE 1.3  (vs #008300)
```

All at or below the palette's existing worst cross-family pair (`#008300`↔`#b93b3f`, deutan ΔE 3.1) → rejected. The chosen `#db9200` (L 0.716) sits between `#c98500` (0.65) and legacy `#eda100` (0.764), with **worst cross-family separation ΔE 8.9**:

```
#db9200 cross-family, light mode
  vs #e5484d : ΔE 10.4 (deutan)      vs #3987e5 : ΔE 28.3 (protan)
  vs #b93b3f : ΔE 19.3 (deutan)      vs #2a78d6 : ΔE 29.2 (protan)
  vs #008300 : ΔE 11.4 (protan)      vs #1f5fa8 : ΔE 30.4 (protan)
  vs #199e70 : ΔE  8.9 (protan)
```

The four family hues — the stated bar — still pass every check in both modes:

```
node scripts/validate_palette.js "#e5484d,#c98500,#008300,#3987e5" --mode dark --surface "#1c1c24" --pairs all
  [PASS] Chroma floor           all 4 >= 0.1
  [WARN] CVD separation         worst all-pairs #c98500↔#e5484d ΔE 6.3 (deutan) · tritan 11.3
  [PASS] Normal-vision floor    worst all-pairs #c98500↔#e5484d ΔE 15.6 (normal)
  [PASS] Contrast vs surface    all 4 >= 3:1
  → ALL CHECKS PASS
```
Identical result with `--mode light --surface "#ffffff"`.

Full 10-hue run, both modes: **the worst cross-family pair is unchanged at ΔE 3.1** — the new hue introduces no collision. Its only close pairs are the other ambers (within-family, below the normal-vision floor by design, carried by the legend and tooltip), and it warns on light-mode contrast at 2.59 — the same accepted trade the neighbouring `#eda100` already makes at 2.17.

## Verification

`npx tsc -b` — clean, exit 0. (Requires `npm ci` first; the checkout had no `node_modules`, which surfaces as a misleading `TS2688: Cannot find type definition file for 'node'`.)

## Two things worth a reviewer's eye

- **No `THINKS_BY_DEFAULT` set exists in `server/ai.ts`** — the file has no `thinking` parameter at all, so there was nothing to add the alias to. Opus 5 has adaptive thinking on by default, but so does the Opus 4.8 it replaces, so this bumps no exposure that wasn't already there. If `MAX_OUTPUT_TOKENS = 1024` ever truncates AI Insights answers, that guard is the missing piece — out of scope here.
- **Sonnet 5 introductory pricing** is $2/$10 through 2026-08-31, reverting to the $3/$15 already in `PRICING_DATA`. Not touched (Sonnet 5 isn't new), but the app currently overstates Sonnet 5 cost by ~50% until September.

Claude Mythos Preview (`claude-mythos-preview`) was skipped: invitation-only and carries no published price, so adding it would risk the exact mispricing this change fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcpCRUUQ9Jn7GDHaW3nPqQ)_