### PR TITLE
fix(pricing): Sonnet 5 is $2/$10 standard, not $3/$15

### DIFF
--- a/server/pricing.ts
+++ b/server/pricing.ts
@@ -16,7 +16,10 @@ const TABLE: Array<[RegExp, Price]> = [
   [/opus-5|opus-4-[5-8]|opus-4\.[5-8]/i, { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 }],
   // Legacy Claude Opus (3.0, 4.0, 4.1) priced at 15 / 75
   [/opus/i, { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 }],
-  // Claude Sonnet (all versions: 3.0, 3.5, 4.5, 4.6, 5) priced at 3 / 15
+  // Claude Sonnet 5 priced at 2 / 10 — the launch "introductory" rate is now the
+  // standard price; the scheduled 2026-09-01 increase to 3 / 15 was cancelled.
+  [/sonnet-5/i, { input: 2, output: 10, cacheWrite: 2.50, cacheRead: 0.2 }],
+  // Older Claude Sonnet (3.0, 3.5, 4.0, 4.5, 4.6) priced at 3 / 15
   [/sonnet/i, { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 }],
   // Claude Haiku 4.5 priced at 1 / 5
   [/haiku-4/i, { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.1 }],

--- a/src/components/design-system/organisms/CostCalculation/utils.ts
+++ b/src/components/design-system/organisms/CostCalculation/utils.ts
@@ -10,7 +10,7 @@ export const PRICING_DATA: ModelPrice[] = [
   { name: 'Claude Opus 4.5', family: 'opus-4-5', input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
   { name: 'Claude Opus 4.1 (deprecated)', family: 'opus-4-1', input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 },
   { name: 'Claude Opus 4 (deprecated)', family: 'opus-4', input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 },
-  { name: 'Claude Sonnet 5', family: 'sonnet-5', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3, popular: true },
+  { name: 'Claude Sonnet 5', family: 'sonnet-5', input: 2, output: 10, cacheWrite: 2.5, cacheRead: 0.2, popular: true },
   { name: 'Claude Sonnet 4.6', family: 'sonnet-4-6', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
   { name: 'Claude Sonnet 4.5', family: 'sonnet-4-5', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
   { name: 'Claude Sonnet 4 (deprecated)', family: 'sonnet-4', input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },


### PR DESCRIPTION
## What changed

Claude Sonnet 5 is repriced from **$3/$15** to **$2/$10** per MTok in both hardcoded pricing tables.

## Why — and why this reverses an earlier decision

This was previously raised and **deliberately declined**, on the reasoning that $2/$10 was a time-limited introductory rate expiring 2026-08-31, after which the table's $3/$15 would become correct on its own. **Anthropic has since cancelled that reversion**, so the table will never self-correct.

From [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing), verbatim:

> The $2/$10 per million input/output token pricing for Claude Sonnet 5, announced at launch as introductory pricing through August 31, 2026, is now the standard price. The previously scheduled increase to $3/$15 per million input/output tokens on September 1, 2026 will not occur.

This is now a **standard rate change**, not a promotional one, so it belongs in the tables. Left as-is, every Sonnet 5 USD figure in the app is overstated by 50%, permanently and with no symptom.

## Published figures

| | Base input | 5m cache write | Cache hits | Output |
|---|---|---|---|---|
| Claude Sonnet 5 | $2 / MTok | $2.50 / MTok | $0.20 / MTok | $10 / MTok |

Cache values also satisfy the table's convention: `cacheWrite = 1.25x input`, `cacheRead = 0.1x input`.

## Files touched

**`src/components/design-system/organisms/CostCalculation/utils.ts`** — the `Claude Sonnet 5` `PRICING_DATA` row: `input: 3 → 2`, `output: 15 → 10`, `cacheWrite: 3.75 → 2.5`, `cacheRead: 0.3 → 0.2`. Position and `popular: true` unchanged.

**`server/pricing.ts`** — `TABLE` rows are shared by tier and `/sonnet/i` covers *every* Sonnet, so the row is **split rather than edited in place**; editing it would have silently repriced Sonnet 4.6/4.5/4/3.x too. A specific `/sonnet-5/i` row is inserted **above** the general `/sonnet/i` row (first match wins).

### Which models each edited row covers

Verified by calling `estimateCost()` on real model IDs against the built table:

| Model ID | Row matched | Input / Output |
|---|---|---|
| `claude-sonnet-5` | **`/sonnet-5/i` (new)** | **$2 / $10** |
| `claude-sonnet-4-6` | `/sonnet/i` | $3 / $15 |
| `claude-sonnet-4-5-20250929` | `/sonnet/i` | $3 / $15 |
| `claude-sonnet-4-20250514` | `/sonnet/i` | $3 / $15 |
| `claude-3-5-sonnet-20241022` | `/sonnet/i` | $3 / $15 |
| `claude-3-sonnet-20240229` | `/sonnet/i` | $3 / $15 |

Exactly one model moved. All Opus, Fable, Mythos and Haiku rows were re-checked against the published table and are unchanged and correct. No rows were deleted.

## Verification

`npx tsc -b` — clean, exit 0.

## Out of scope — separate pre-existing bug worth a look

While verifying row resolution I found an unrelated defect I did **not** touch, since it isn't this change:

The Haiku 3.5 row `/haiku-3-[5-9]|haiku-3\.[5-9]/i` never matches a real model ID. Anthropic's ID is `claude-3-5-haiku-20241022` — the version precedes `haiku`, so the pattern can't match. It falls through to the bare `/haiku/i` row and prices at **$0.25/$1.25 instead of the published $0.80/$4** — underpriced 3.2x, with the intended row sitting there as dead code. A pattern like `/3-5-haiku|haiku-3-[5-9]/i` would fix it. Flagging rather than folding it into a pricing PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxL2e8NaMG6HRmbvNgYddH)_