### PR TITLE
feat(trends): extend spending time range up to 1 year with expanded UI presets

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -386,7 +386,7 @@ app.post('/api/auto-resume/test', async (req, res) => {
 // return wrap({ error }) at HTTP 200 so the frontend just hides the cards.
 app.get('/api/usage/litellm', async (req, res) => {
   try {
-    const days = Math.max(7, Math.min(28, Number(req.query.days ?? 7)));
+    const days = Math.max(7, Math.min(365, Number(req.query.days ?? 7)));
     res.json(wrap(await fetchLiteLlmSpend(days), Date.now()));
   } catch (e: any) {
     res.json(wrap({ error: e.message || String(e) }, Date.now()));
@@ -410,7 +410,7 @@ app.get('/api/usage/recent', async (req, res) => {
 
 app.get('/api/usage/weekly', async (req, res) => {
   try {
-    const days = Math.max(7, Math.min(28, Number(req.query.days ?? 7)));
+    const days = Math.max(7, Math.min(365, Number(req.query.days ?? 7)));
     const { events, computedAt } = await getEvents();
     const source = parseSource(req.query.source);
     const data = memoBuilder('weekly', [days, source], eventsFingerprint(), () =>

--- a/server/scan.ts
+++ b/server/scan.ts
@@ -608,7 +608,7 @@ function localYmd(d: Date): string {
  * `days`, so switching the window reuses the cache. Throws distinct messages so the
  * route can degrade gracefully (no permission / not a LiteLLM gateway / outage).
  */
-async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
+async function fetchLiteLlmBase(days = 7): Promise<LiteLlmBase> {
   const base = litellmBaseUrl();
   const token = litellmAuthToken();
   if (!base || !token) throw new Error('LiteLLM gateway not configured');
@@ -620,7 +620,9 @@ async function fetchLiteLlmBase(): Promise<LiteLlmBase> {
   // Same day-of-month in the previous month, clamped to its last day, for a
   // fair "same point in the month" comparison.
   const prevMonthEnd = new Date(today.getFullYear(), today.getMonth() - 1, Math.min(today.getDate(), prevMonthLastDay));
-  const startYmd = localYmd(prevMonthStart);
+  const daysStart = new Date(today.getFullYear(), today.getMonth(), today.getDate() - days);
+  const effectiveStart = daysStart < prevMonthStart ? daysStart : prevMonthStart;
+  const startYmd = localYmd(effectiveStart);
   const endYmd = localYmd(today);
   const monthStartYmd = localYmd(monthStart);
   const prevEndYmd = localYmd(prevMonthEnd);
@@ -732,7 +734,7 @@ async function fetchLiteLlmAccount(): Promise<{ user: number; key: number }> {
 /** Actual billed spend: month-to-date, previous-month same-period total, and the
  *  last `days` calendar days (incl. today, zero-filled) with per-model breakdown. */
 export async function fetchLiteLlmSpend(days: number): Promise<LiteLlmSpend> {
-  const b = await fetchLiteLlmBase();
+  const b = await fetchLiteLlmBase(days);
   const lifetime = await fetchLiteLlmAccount();
   const daily: LiteLlmSpend['daily'] = [];
   for (let i = days - 1; i >= 0; i--) {

--- a/src/components/tabs/TrendsTab/TrendsTab.tsx
+++ b/src/components/tabs/TrendsTab/TrendsTab.tsx
@@ -21,7 +21,23 @@ import { useLiteLlmActual } from '@/hooks/useLiteLlmActual';
 import { useAiInsightCtx } from '@/hooks/useAiInsightContext';
 import type { ActivityData, HeatmapData } from '@/types';
 
-export function TrendsTab() {
+type TimeWindowOption = {
+  days: number;
+  label: string;
+  periodLabel: string;
+};
+
+const TIME_WINDOWS: TimeWindowOption[] = [
+  { days: 7, label: '1w', periodLabel: 'prev week' },
+  { days: 14, label: '2w', periodLabel: 'prev 2 weeks' },
+  { days: 30, label: '1m', periodLabel: 'prev month' },
+  { days: 60, label: '2m', periodLabel: 'prev 2 months' },
+  { days: 90, label: '3m', periodLabel: 'prev 3 months' },
+  { days: 180, label: '6m', periodLabel: 'prev 6 months' },
+  { days: 365, label: '1y', periodLabel: 'prev year' },
+];
+
+export const TrendsTab = () => {
   const { coworkAvailable, source, withSrc } = useSource();
   const { litellmAvailable, litellmHost, weekStart } = useConfigMode();
   const { weekly, models, weekDays, setWeekDays } = useLiveData();
@@ -35,6 +51,9 @@ export function TrendsTab() {
   const activity = usePolling<ActivityData>(withSrc('/api/activity'), 30000);
   const topModel = models.data?.models[0];
 
+  const currentWindow = TIME_WINDOWS.find((w) => w.days === weekDays);
+  const prevPeriodLabel = currentWindow ? currentWindow.periodLabel : `prev ${weekDays}d`;
+
   return (
     <>
       {/* Window selector — drives the cost stat cards, the estimate chart,
@@ -43,15 +62,15 @@ export function TrendsTab() {
         <span className="text-xs uppercase tracking-wider text-zinc-500">Spending · last {weekDays} days</span>
         <div className="flex items-center gap-3">
           <div className="flex overflow-hidden rounded-lg ring-1 ring-white/10">
-            {[7, 14, 21, 28].map((d) => (
+            {TIME_WINDOWS.map(({ days, label }) => (
               <button
-                key={d}
-                onClick={() => setWeekDays(d)}
+                key={days}
+                onClick={() => setWeekDays(days)}
                 className={`px-2.5 py-1 text-xs tabular-nums transition-colors ${
-                  weekDays === d ? 'bg-clay-500/20 text-clay-400' : 'text-zinc-500 hover:text-zinc-300'
+                  weekDays === days ? 'bg-clay-500/20 text-clay-400' : 'text-zinc-500 hover:text-zinc-300'
                 }`}
               >
-                {d / 7}w
+                {label}
               </button>
             ))}
           </div>
@@ -87,7 +106,7 @@ export function TrendsTab() {
               value={compact(weeklyEffective)}
               sub={
                 prevWeeklyEffective > 0
-                  ? `${weekDays === 7 ? 'prev week' : `prev ${weekDays / 7} weeks`}: ${compact(prevWeeklyEffective)}`
+                  ? `${prevPeriodLabel}: ${compact(prevWeeklyEffective)}`
                   : `${compact(weekly.data?.totals.outputTokens ?? 0)} output`
               }
               help="Input + output + cache-write tokens — the tokens that count toward rate limits. Cheap cache reads are excluded. Compared against the previous period."


### PR DESCRIPTION
## Summary
Extends the spending and trend analytics time range beyond the previous 4-week limit, allowing users to view up to 1 year of historical usage data.

### Changes
- **Backend**:
  - Relaxed `/api/usage/weekly` and `/api/usage/litellm` day clamping from 28 to 365 days in `server/index.ts`.
  - Updated `fetchLiteLlmBase` in `server/scan.ts` to dynamically query sufficient date ranges when longer windows are requested.
- **Frontend**:
  - Expanded the Trends time window selector in `src/components/tabs/TrendsTab/TrendsTab.tsx` with presets: `1w`, `2w`, `1m` (30d), `2m` (60d), `3m` (90d), `6m` (180d), `1y` (365d).
  - Added dynamic comparison period labels for non-weekly intervals (e.g., `prev month`, `prev 3 months`, etc.).